### PR TITLE
docs(console.py): Change 'inline_styes' to 'inline_styles' in 'export_html()' doc.

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -881,7 +881,7 @@ class Console:
             clear (bool, optional): Set to ``True`` to clear the record buffer after generating the HTML.
             code_format (str, optional): Format string to render HTML, should contain {foreground}
                 {background} and {code}.
-            inline_styes (bool, optional): If ``True`` styles will be inlined in to spans, which makes files
+            inline_styles (bool, optional): If ``True`` styles will be inlined in to spans, which makes files
                 larger but easier to cut and paste markup. If ``False``, styles will be embedded in a style tag.
                 Defaults to False.
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
