### PR TITLE
Add input and box tests

### DIFF
--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -1,0 +1,35 @@
+import pytest
+
+from rich.box import ASCII, DOUBLE, ROUNDED, HEAVY
+
+
+def test_str():
+    assert str(ASCII) == "+--+\n| ||\n|-+|\n| ||\n|-+|\n|-+|\n| ||\n+--+\n"
+
+
+def test_repr():
+    assert repr(ASCII) == "Box(...)"
+
+
+def test_get_top():
+    top = HEAVY.get_top(widths=[1, 2])
+    assert top == "┏━┳━━┓"
+
+
+def test_get_row():
+    head_row = DOUBLE.get_row(widths=[3, 2, 1], level="head")
+    assert head_row == "╠═══╬══╬═╣"
+
+    row = ASCII.get_row(widths=[1, 2, 3], level="row")
+    assert row == "|-+--+---|"
+
+    foot_row = ROUNDED.get_row(widths=[2, 1, 3], level="foot")
+    assert foot_row == "├──┼─┼───┤" 
+
+    with pytest.raises(ValueError):
+        ROUNDED.get_row(widths=[1, 2, 3], level="FOO")
+
+
+def test_get_bottom():
+    bottom = HEAVY.get_bottom(widths=[1, 2, 3])
+    assert bottom == "┗━┻━━┻━━━┛"

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -115,6 +115,14 @@ def test_control():
     assert console.file.getvalue() == "FOOBAR\n"
 
 
+def test_input(monkeypatch, capsys):
+    monkeypatch.setattr('builtins.input', lambda: "bar")
+    console = Console()
+    user_input = console.input(prompt="foo:")
+    assert capsys.readouterr().out == "foo:"
+    assert user_input == "bar"
+
+
 class BrokenRenderable:
     def __console__(self, console, options):
         pass


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [X] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description
I have added `test_box.py` with additional box.py tests and I have added a basic test for console.input() in `test_console.py` for issue #37.

Unfortunately, the total coverage didn't change from 94% but hope it helps in the long run. Let me know if I should change anything. Thanks!
