### PR TITLE
Allow for easier subclassing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Udated `markdown.Heading.create()` to work with subclassing.
+
 ## [1.2.3] - 2020-05-24
 
 ### Added

--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -133,7 +133,7 @@ class Heading(TextElement):
 
     @classmethod
     def create(cls, markdown: "Markdown", node: Any) -> "Heading":
-        heading = Heading(node.level)
+        heading = cls(node.level)
         return heading
 
     def on_enter(self, context: "MarkdownContext") -> None:


### PR DESCRIPTION
## Type of changes
Allow for DRY:er subclasses by allowing us to reuse `Heading.create`

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
   - There's no CONTRIBUTORS.md file to update, I did update the CHANGELOG.md
- [ ] I've added tests for new code.
   - This is a tiny change mainly changing one function to adhere to the other functions. Since you are currently not testing subclassing for the other classes I didn't add anyone here.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

The `markdown.Headings` class unlike all other `MarkdownElement` subclasses were using an explicit self reference in it's factory/create-method. This forced us to overload the create-method every time subclassing Heading so that we could reference the new subclass instead (or as I used, a self reference). By using the implicit `cls`-reference instead we don't need to overload the create method making code inheriting Heading DRY:er and less error-prone if create-method internals is changed in the future. All the other markdown element classes already uses this approach.

**Example of how a Heading subclass could look today:**
```python
class SubtleHeading(Heading):
    @classmethod
    def create(cls, markdown: "Markdown", node: Any) -> "Heading":
        heading = cls(node.level)
        return heading

    def __init__(self, level):
        # Defering all headings by one level to avoid the borderd box for H1, hence level 2 is max
        super().__init__(level + 1)

    def __rich_console__(
        self, console: Console, options: ConsoleOptions
    ) -> RenderResult:
        # Overwriting this to avoid the center-alginment
        # h1 is unused since we defer all levels by one level
        text = self.text
        # Styled text for h2 and beyond
        if self.level == 2:
            yield Text("\n")
        yield text
```

**Same change after this PR:**
```python
class SubtleHeading(Heading):
    def __init__(self, level):
        # Defering all headings by one level to avoid the borderd box for H1, hence level 2 is max
        super().__init__(level + 1)

    def __rich_console__(
        self, console: Console, options: ConsoleOptions
    ) -> RenderResult:
        # Overwriting this to avoid the center-alginment
        # h1 is unused since we defer all levels by one level
        text = self.text
        # Styled text for h2 and beyond
        if self.level == 2:
            yield Text("\n")
        yield text
```

For additional background, I discovered this as a follow up to this [twitter thread](https://twitter.com/ahultner/status/1265253708499124225).
