### PR TITLE
Lower case "console" in import makes example fail

### DIFF
--- a/docs/source/syntax.rst
+++ b/docs/source/syntax.rst
@@ -6,7 +6,7 @@ Rich can syntax highlight various programming languages with line numbers.
 To syntax highlight code, construct a :class:`~rich.syntax.Syntax` object and print it to the console. Here's an example::
 
 
-    from rich.console import console
+    from rich.console import Console
     from rich.syntax import Syntax
 
     console = Console()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [X] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

This is a tiny fix to the code in the docs so the syntax example code works - hopefully you're fine I didn't run black, update CHANGELOG.md etc (given how small change is)

BTW: this library is awesome :sunglasses:  - thank you for creating it!
