### PR TITLE
enable emojis for rich logging handler

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -589,7 +589,7 @@ class Console:
             rich_text.overflow = overflow
         else:
             rich_text = Text(
-                _emoji_replace(text) if emoji_enabled else text,
+                self.emoji_replace(text, emoji_enabled),
                 justify=justify,
                 overflow=overflow,
                 style=style,
@@ -642,7 +642,7 @@ class Console:
         """Combined a number of renderables and text in to one renderable.
 
         Args:
-            renderables (Iterable[Union[str, ConsoleRenderable]]): Anyting that Rich can render.
+            renderables (Iterable[Union[str, ConsoleRenderable]]): Anything that Rich can render.
             sep (str, optional): String to write between print data. Defaults to " ".
             end (str, optional): String to write at end of print data. Defaults to "\n". 
             justify (str, optional): One of "left", "right", "center", or "full". Defaults to ``None``.       
@@ -731,6 +731,13 @@ class Console:
 
         self._buffer.append(Segment.control(str(control_codes)))
         self._check_buffer()
+
+    def emoji_replace(self, text: str, emoji=None):
+        emoji_enabled = emoji or (emoji is None and self._emoji)
+        if emoji_enabled:
+            return _emoji_replace(text)
+        else:
+            return text
 
     def print(
         self,

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -34,6 +34,7 @@ class RichHandler(Handler):
         path = Path(record.pathname).name
         log_style = f"logging.level.{record.levelname.lower()}"
         message = self.format(record)
+        message = self.console.emoji_replace(message)
         time_format = None if self.formatter is None else self.formatter.datefmt
         log_time = datetime.fromtimestamp(record.created)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -25,6 +25,13 @@ def test_log():
     assert render == expected
 
 
+def test_emoji():
+    from rich.emoji import Emoji
+
+    log.debug(":thumbs_up:")
+    assert Emoji.replace(":thumbs_up:") in handler.console.file.getvalue()
+
+
 if __name__ == "__main__":
     render = make_log()
     print(render)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [X] Tests
- [X] Other

## Checklist

- [X] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
I didn't do this since it's a small change.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

:)

## Description

Run logged strings through _emoji_replace so we can use the emoji shorthand in conjunction with rich's logging handler :). Add basic test.