### PR TITLE
new link ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.6] - 2020-06-24
+
+### Changed
+
+- Store a "link id" on Style instance, so links containing different styles are highlighted together.
+
 ## [2.2.5] - 2020-06-23
 
 ### Fixed

--- a/examples/link.py
+++ b/examples/link.py
@@ -1,0 +1,5 @@
+from rich import print
+
+print("If your terminal supports links, the following text should be clickable:")
+print("[link=https://www.willmcgugan.com][i]Visit [red]my[/red][/i] [yellow]Blog[/]")
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "rich"
 homepage = "https://github.com/willmcgugan/rich"
 documentation = "https://rich.readthedocs.io/en/latest/"
-version = "2.2.5"
+version = "2.2.6"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 authors = ["Will McGugan <willmcgugan@gmail.com>"]
 license = "MIT"

--- a/rich/console.py
+++ b/rich/console.py
@@ -649,7 +649,7 @@ class Console:
 
         try:
             style = self._styles.get(name)
-            return style if style is not None else Style.parse(name)
+            return style.copy() if style is not None else Style.parse(name).copy()
         except errors.StyleSyntaxError as error:
             if default is not None:
                 return self.get_style(default)

--- a/rich/style.py
+++ b/rich/style.py
@@ -483,7 +483,7 @@ class Style:
         style._attributes = self._attributes
         style._set_attributes = self._set_attributes
         style._link = self._link
-        style._link_id = self._link_id
+        style._link_id = f"{time()}-{randint(0, 999999)}" if self._link else ""
         return style
 
     def render(
@@ -509,6 +509,7 @@ class Style:
             rendered = (
                 f"\x1b]8;id={self._link_id};{self._link}\x1b\\{rendered}\x1b]8;;\x1b\\"
             )
+
         return rendered
 
     def test(self, text: Optional[str] = None) -> None:

--- a/tests/render.py
+++ b/tests/render.py
@@ -4,11 +4,14 @@ import re
 from rich.console import Console, RenderableType
 
 
-re_link_ids = re.compile(r"id=\d*?;.*?\x1b")
+re_link_ids = re.compile(r"id=[\d\.\-]*?;.*?\x1b")
 
 
 def replace_link_ids(render: str) -> str:
-    """Link IDs have a random ID and system path which is a problem for reproducable tests."""
+    """Link IDs have a random ID and system path which is a problem for
+    reproducible tests.
+    
+    """
     return re_link_ids.sub("id=0;foo\x1b", render)
 
 


### PR DESCRIPTION
Adds a link id to the Style class. Link ids are used when generating the ansi codes for links, so that the terminal knows which cells to highlight.

Formerly if a link contained multiple styles, the terminal would highlight individually styled portions of text on hover rather than the entire link. 

For example, printing this would look like the words ``Hello`` and ``World`` were two links, when they are actually one link.

"[link=https://example.org]Hello [b]World![/b][/link]"

This PR fixes that.


## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.


