### PR TITLE
Syntax module: correct description

### DIFF
--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -298,7 +298,7 @@ if __name__ == "__main__":  # pragma: no cover
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Render Markdown to the console with Rich"
+        description="Render syntax to the console with Rich"
     )
     parser.add_argument("path", metavar="PATH", help="path to file")
     parser.add_argument(


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Description
The syntax command line tool, displays markdown as the type of render.


<img width="666" alt="Screenshot 2020-07-06 at 3 15 42 PM" src="https://user-images.githubusercontent.com/2987087/86579953-a5c1d080-bf9b-11ea-9910-cacb125efa32.png">

Also, black was changing files I didn't modify, so I didn't commit that.