### PR TITLE
Fix docstr in text.py (Trip to Strip) in rstrip

### DIFF
--- a/rich/text.py
+++ b/rich/text.py
@@ -406,7 +406,7 @@ class Text(JupyterMixin):
         return count
 
     def rstrip(self) -> None:
-        """Trip whitespace from end of text."""
+        """Strip whitespace from end of text."""
         self.plain = self.plain.rstrip()
 
     def rstrip_end(self, size: int):


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fix docstr in text.py (Trip to Strip) in rstrip()
