### PR TITLE
Logging docs - fix 'extras' typo

### DIFF
--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -16,8 +16,8 @@ Here's an example of how to set up a rich logger::
     log = logging.getLogger("rich")
     log.info("Hello, World!")
 
-Rich logs won't process console markup by default, but you can enable markup per log statement with the ``extras`` argument as follows::
+Rich logs won't process console markup by default, but you can enable markup per log statement with the ``extra`` argument as follows::
 
-    log.error("[bold red blink]Server is shutting down![/]", extras={"markup": True})
+    log.error("[bold red blink]Server is shutting down![/]", extra={"markup": True})
 
 There are a number of options you can use to configure logging output, see the :class:`~rich.logging.RichHandler` reference for details.


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Running the example code for logging at https://rich.readthedocs.io/en/latest/logging.html with the `extras={"markup": True}` example, I get the following error:

```python
Traceback (most recent call last):
  File "minimal_example/test.py", line 9, in <module>
    log.error("[bold red blink]Server is shutting down![/]", extras={"markup": True})
  File "/Users/philewels/miniconda2/envs/python3/lib/python3.6/logging/__init__.py", line 1335, in error
    self._log(ERROR, msg, args, **kwargs)
TypeError: _log() got an unexpected keyword argument 'extras'
```

Looking over the [Python `logging` docs](https://docs.python.org/3.8/library/logging.html#logging.Logger.debug), it seems that the logging argument is `extra` without the `s`:

> There are four keyword arguments in _kwargs_ which are inspected: _exc_info_, _stack_info_, _stacklevel_ and **_extra_**.

Changing this solves the error for me.
