### PR TITLE
Add black format check to ci

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,6 +21,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           poetry install
+      - name: Format check with black
+        run: |
+          make format
       - name: Typecheck with mypy
         run: |
           make typecheck

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 test:
 	pytest --cov-report term-missing --cov=rich tests/ -vv
+format:
+	black --check rich
 typecheck:
 	mypy -p rich --ignore-missing-imports --warn-unreachable
 typecheck-report:

--- a/rich/_palettes.py
+++ b/rich/_palettes.py
@@ -299,4 +299,3 @@ EIGHT_BIT_PALETTE = Palette(
         (238, 238, 238),
     ]
 )
-


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [X] Other

## Checklist

- [X] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added a check for black formatting to ensure only formatted code is merged to the master branch.
