### PR TITLE
Fix deprecation warnings due to invalid escape sequences.

### DIFF
--- a/rich/markup.py
+++ b/rich/markup.py
@@ -47,7 +47,7 @@ def escape(markup: str) -> str:
     Returns:
         str: Markup with square brackets escaped.
     """
-    return markup.replace("[", "\[")
+    return markup.replace("[", r"\[")
 
 
 def _parse(markup: str) -> Iterable[Tuple[int, Optional[str], Optional[Tag]]]:

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -23,11 +23,11 @@ def test_re_match():
 
 
 def test_escape():
-    assert escape("foo[bar]") == "foo\[bar]"
+    assert escape("foo[bar]") == r"foo\[bar]"
 
 
 def test_parse():
-    result = list(_parse("[foo]hello[/foo][bar]world[/]\[escaped]"))
+    result = list(_parse(r"[foo]hello[/foo][bar]world[/]\[escaped]"))
     expected = [
         (0, None, Tag(name="foo", parameters=None)),
         (10, "hello", None),


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #210 
