### PR TITLE
Tests on traceback to 100% coverage

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -208,7 +208,9 @@ class Traceback:
                 exc_value = cause
                 traceback = cause.__traceback__
                 continue
-            break
+            # No cover, code is reached but coverage doesn't recognize it.
+            break  # pragma: no cover
+
         trace = Trace(stacks=stacks)
         return trace
 

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -6,7 +6,7 @@ import pytest
 from rich.console import Console
 from rich.traceback import install, Traceback
 
-from .render import render
+# from .render import render
 
 try:
     from ._exception_render import expected
@@ -90,6 +90,32 @@ def test_syntax_error():
         console.print_exception()
     exception_text = console.file.getvalue()
     assert "SyntaxError" in exception_text
+
+
+def test_nested_exception():
+    console = Console(width=100, file=io.StringIO())
+    value_error_message = "ValueError because of ZeroDivisionEerror"
+
+    try:
+        try:
+            1 / 0
+        except ZeroDivisionError:
+            raise ValueError(value_error_message)
+    except Exception:
+        console.print_exception()
+    exception_text = console.file.getvalue()
+
+    text_should_contain = [
+        value_error_message,
+        "ZeroDivisionError",
+        "ValueError",
+        "During handling of the above exception",
+    ]
+
+    assert [msg in exception_text for msg in text_should_contain]
+
+    # ZeroDivisionError should come before ValueError
+    assert exception_text.find("ZeroDivisionError") < exception_text.find("ValueError")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -125,7 +125,7 @@ def test_filename_with_bracket():
     except Exception:
         console.print_exception()
     exception_text = console.file.getvalue()
-    assert 'File "<\string>"' in exception_text
+    assert 'File "<string>"' in exception_text
 
 
 def test_filename_not_a_file():
@@ -135,7 +135,7 @@ def test_filename_not_a_file():
     except Exception:
         console.print_exception()
     exception_text = console.file.getvalue()
-    assert 'File "\string"' in exception_text
+    assert 'File "string"' in exception_text
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -118,6 +118,26 @@ def test_nested_exception():
     assert exception_text.find("ZeroDivisionError") < exception_text.find("ValueError")
 
 
+def test_filename_with_bracket():
+    console = Console(width=100, file=io.StringIO())
+    try:
+        exec(compile("1/0", filename="<string>", mode="exec"))
+    except Exception:
+        console.print_exception()
+    exception_text = console.file.getvalue()
+    assert "File \"<\string>\"" in exception_text
+
+
+def test_filename_not_a_file():
+    console = Console(width=100, file=io.StringIO())
+    try:
+        exec(compile("1/0", filename="string", mode="exec"))
+    except Exception:
+        console.print_exception()
+    exception_text = console.file.getvalue()
+    assert "File \"\string\"" in exception_text
+
+
 if __name__ == "__main__":  # pragma: no cover
 
     expected = render(get_exception())

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -81,6 +81,17 @@ def test_print_exception():
     assert "ZeroDivisionError" in exception_text
 
 
+def test_syntax_error():
+    console = Console(width=100, file=io.StringIO())
+    try:
+        # raises SyntaxError: unexpected EOF while parsing
+        eval("(2 + 2")
+    except Exception:
+        console.print_exception()
+    exception_text = console.file.getvalue()
+    assert "SyntaxError" in exception_text
+
+
 if __name__ == "__main__":  # pragma: no cover
 
     expected = render(get_exception())

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -125,7 +125,7 @@ def test_filename_with_bracket():
     except Exception:
         console.print_exception()
     exception_text = console.file.getvalue()
-    assert "File \"<\string>\"" in exception_text
+    assert 'File "<\string>"' in exception_text
 
 
 def test_filename_not_a_file():
@@ -135,7 +135,7 @@ def test_filename_not_a_file():
     except Exception:
         console.print_exception()
     exception_text = console.file.getvalue()
-    assert "File \"\string\"" in exception_text
+    assert 'File "\string"' in exception_text
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code. **But** there was a file (`tests/_card_render.py`) about which black complained, but this one isn't included in the changes.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Another small contribution to #37 . I am not so sure about the last two tests, because I couldn't exactly pinpoint what the traceback is supposed to do in those cases. 

Also: I added a `no cover` statement. I noticed that when I add a print statement before the `break`, both the `break` and the print are reached according to coverage (which makes sense). When I remove the print, the `break` isn't reached anymore. Not sure what happens there, might be a bug in ~~pytest~~ _coveragepy_?

Happy to make some changes / additions to this PR. Let me know if you need or want it. Thanks!


**Edit:** formatting and small change in wording