### PR TITLE
Check black format in tests dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test:
 	pytest --cov-report term-missing --cov=rich tests/ -vv
 format:
-	black --check rich
+	black --check rich tests
 typecheck:
 	mypy -p rich --ignore-missing-imports --warn-unreachable
 typecheck-report:

--- a/examples/columns.py
+++ b/examples/columns.py
@@ -18,6 +18,7 @@ def get_content(user):
     name = f"{user['name']['first']} {user['name']['last']}"
     return f"[b]{name}[/b]\n[yellow]{country}"
 
+
 console = Console()
 
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -32,4 +32,3 @@ def test_lines_rich_console():
 
     result = list(lines.__rich_console__(console, console.options))
     assert result == [Text("foo")]
-

--- a/tools/profile_pretty.py
+++ b/tools/profile_pretty.py
@@ -5,7 +5,6 @@ from rich.console import Console
 from rich.pretty import Pretty
 
 
-
 console = Console(file=io.StringIO(), color_system="truecolor", width=100)
 
 with open("cats.json") as fh:

--- a/tools/stress_test_pretty.py
+++ b/tools/stress_test_pretty.py
@@ -9,4 +9,3 @@ DATA = {
 console = Console()
 for w in range(130):
     console.print(Panel(Pretty(DATA), width=w))
-


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I think that the tests should also be black formatted, so I added that to the Makefile. And I also formatted all the code including ones in the example and tools directories.

**Things I’m not sure about which I haven’t done:**
1. Need your opinion on changing it instead to `black --check .` (with the dot), so that all python files, like the ones in examples/ are formatted. Tried this locally and it seems fine
2. Need your opinion about the naming in the Makefile: `black --check <whatever>` could be renamed to `make format-check`, and then `make format` could be instead `black <whatever>`

\* The \<whatever> part depends on what you think about the dot thing (in 1.)