### PR TITLE
Remove typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Here are a few projects using Rich:
 - [intel/cve-bin-tool](https://github.com/intel/cve-bin-tool)
   This tool scans for a number of common, vulnerable components (openssl, libpng, libxml2, expat and a few others) to let you know if your system includes common libraries with known vulnerabilities.
 - [nf-core/tools](https://github.com/nf)
-  Python package with helper tools for the nf-core community.-core/tools)
+  Python package with helper tools for the nf-core community.
 - [cansarigol/pdbr](https://github.com/cansarigol/pdbr)
   pdb + Rich library for enhanced debugging
 - [plant99/felicette](https://github.com/plant99/felicette)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

in the original README.md in projects using Rich, the description for nf-core/tools is: Python package with helper tools for the nf-core community.-core/tools), where "-core/tools)" is a typo and should be removed.
