### PR TITLE
Add the ability to force terminal with environment variable

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -352,7 +352,9 @@ class Console:
         )
 
         self._color_system: Optional[ColorSystem]
-        self._force_terminal = force_terminal if self._environ.get("FORCE_TERMINAL") is None else True
+        self._force_terminal = (
+            force_terminal if self._environ.get("FORCE_TERMINAL") is None else True
+        )
         self.file = file or sys.stdout
 
         if color_system is None:

--- a/rich/console.py
+++ b/rich/console.py
@@ -352,7 +352,7 @@ class Console:
         )
 
         self._color_system: Optional[ColorSystem]
-        self._force_terminal = force_terminal
+        self._force_terminal = force_terminal if self._environ.get("FORCE_TERMINAL") is None else True
         self.file = file or sys.stdout
 
         if color_system is None:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -18,6 +18,9 @@ def test_dumb_terminal():
     console = Console(force_terminal=True)
     assert console.color_system is not None
 
+    console = Console(_environ={"FORCE_TERMINAL": "1"})
+    assert console.color_system is not None
+
     console = Console(force_terminal=True, _environ={"TERM": "dumb"})
     assert console.color_system is None
     width, height = console.size


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add the ability to set Console force_terminal from `FORCE_TERMINAL` environment variable. Useful for places such as CI tools.