### PR TITLE
inline code in Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.0] - 2020-09-13
+
+### Added
+
+- Added inline code highlighting to Markdown
+
 ## [6.1.2] - 2020-09-11
 
 ### Added

--- a/examples/group2.py
+++ b/examples/group2.py
@@ -2,9 +2,11 @@ from rich import print
 from rich.console import render_group
 from rich.panel import Panel
 
+
 @render_group()
 def get_panels():
     yield Panel("Hello", style="on blue")
     yield Panel("World", style="on red")
+
 
 print(Panel(get_panels()))

--- a/examples/padding.py
+++ b/examples/padding.py
@@ -1,4 +1,5 @@
 from rich import print
 from rich.padding import Padding
+
 test = Padding("Hello", (2, 4), style="on blue", expand=False)
 print(test)

--- a/rich/console.py
+++ b/rich/console.py
@@ -182,7 +182,7 @@ class RenderGroup:
 
 def render_group(fit: bool = False) -> Callable:
     """A decorator that turns an iterable of renderables in to a group."""
-    
+
     def decorator(method):
         """Convert a method that returns an iterable of renderables in to a RenderGroup."""
 

--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -5,13 +5,7 @@ from commonmark.blocks import Parser
 from . import box
 from ._loop import loop_first
 from ._stack import Stack
-from .console import (
-    Console,
-    ConsoleOptions,
-    JustifyMethod,
-    RenderResult,
-    Segment,
-)
+from .console import Console, ConsoleOptions, JustifyMethod, RenderResult, Segment
 from .containers import Renderables
 from .jupyter import JupyterMixin
 from .panel import Panel
@@ -354,8 +348,8 @@ class MarkdownContext:
         console: Console,
         options: ConsoleOptions,
         style: Style,
-        inline_code_theme: str,
         inline_code_lexer: str = None,
+        inline_code_theme: str = "monokai",
     ) -> None:
         self.console = console
         self.options = options
@@ -428,8 +422,8 @@ class Markdown(JupyterMixin):
         justify: JustifyMethod = None,
         style: Union[str, Style] = "none",
         hyperlinks: bool = True,
-        inline_code_theme: str = None,
         inline_code_lexer: str = None,
+        inline_code_theme: str = None,
     ) -> None:
         self.markup = markup
         parser = Parser()
@@ -450,8 +444,8 @@ class Markdown(JupyterMixin):
             console,
             options,
             style,
-            inline_code_theme=self.inline_code_theme,
             inline_code_lexer=self.inline_code_lexer,
+            inline_code_theme=self.inline_code_theme,
         )
         nodes = self.parsed.walker()
         inlines = self.inlines

--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -397,10 +397,10 @@ class Markdown(JupyterMixin):
         justify (JustifyMethod, optional): Justify value for paragraphs. Defaults to None.
         style (Union[str, Style], optional): Optional style to apply to markdown.
         hyperlinks (bool, optional): Enable hyperlinks. Defaults to ``True``.
+        inline_code_lexer: (str, optional): Lexer to use if inline code highlighting is
+            enabled. Defaults to "python".
         inline_code_theme: (Optional[str], optional): Pygments theme for inline code
             highlighting, or None for no highlighting. Defaults to None.
-        inline_code_lexter: (str, optional): Lexer to use if inline code highlighting is
-            enabled. Defaults to "python".
     """
 
     elements: ClassVar[Dict[str, Type[MarkdownElement]]] = {

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -173,18 +173,16 @@ class Syntax(JupyterMixin):
         style = style + Style(bgcolor=self._pygments_style_class.background_color)
         return style
 
-    def highlight(self, code: str = None) -> Text:
+    def highlight(self, code: str) -> Text:
         """Highlight code and return a Text instance.
 
         Args:
-            code (Optional[str], optional). Highlight code if a str is given, or
-                None to use self.code.
+            code (str). Code to highlight.
 
         Returns:
             Text: A text instance containing syntax highlight.
         """
-        if code is None:
-            code = self.code
+
         default_style = self._get_default_style()
         try:
             lexer = get_lexer_by_name(self.lexer_name)
@@ -255,7 +253,7 @@ class Syntax(JupyterMixin):
         code = self.code
         if self.dedent:
             code = textwrap.dedent(code)
-        text = self.highlight()
+        text = self.highlight(self.code)
         if text.plain.endswith("\n"):
             text.plain = text.plain[:-1]
         if not self.line_numbers:

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -11,7 +11,7 @@ from pygments.util import ClassNotFound
 
 from ._loop import loop_first
 from .color import Color, blend_rgb, parse_rgb_hex
-from .console import Console, ConsoleOptions, RenderResult, Segment
+from .console import Console, ConsoleOptions, JustifyMethod, RenderResult, Segment
 from .jupyter import JupyterMixin
 from .measure import Measurement
 from .style import Style
@@ -173,18 +173,25 @@ class Syntax(JupyterMixin):
         style = style + Style(bgcolor=self._pygments_style_class.background_color)
         return style
 
-    def _highlight(self, lexer_name: str) -> Text:
+    def highlight(self, code: str = None) -> Text:
+        """Highlight a string with the given lexter and return a Text instance.
+
+        Returns:
+            Text: A text instance containing highlights.
+        """
+        if code is None:
+            code = self.code
         default_style = self._get_default_style()
         try:
-            lexer = get_lexer_by_name(lexer_name)
+            lexer = get_lexer_by_name(self.lexer_name)
         except ClassNotFound:
             return Text(
-                self.code, justify="left", style=default_style, tab_size=self.tab_size
+                code, justify="left", style=default_style, tab_size=self.tab_size
             )
         text = Text(justify="left", style=default_style, tab_size=self.tab_size)
         append = text.append
         _get_theme_style = self._get_theme_style
-        for token_type, token in lexer.get_tokens(self.code):
+        for token_type, token in lexer.get_tokens(code):
             append(token, _get_theme_style(token_type))
         return text
 
@@ -244,7 +251,7 @@ class Syntax(JupyterMixin):
         code = self.code
         if self.dedent:
             code = textwrap.dedent(code)
-        text = self._highlight(self.lexer_name)
+        text = self.highlight()
         if text.plain.endswith("\n"):
             text.plain = text.plain[:-1]
         if not self.line_numbers:

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -174,10 +174,14 @@ class Syntax(JupyterMixin):
         return style
 
     def highlight(self, code: str = None) -> Text:
-        """Highlight a string with the given lexter and return a Text instance.
+        """Highlight code and return a Text instance.
+
+        Args:
+            code (Optional[str], optional). Highlight code if a str is given, or
+                None to use self.code.
 
         Returns:
-            Text: A text instance containing highlights.
+            Text: A text instance containing syntax highlight.
         """
         if code is None:
             code = self.code

--- a/rich/text.py
+++ b/rich/text.py
@@ -527,12 +527,13 @@ class Text(JupyterMixin):
 
         _Segment = Segment
         style_cache: Dict[Tuple[int, ...], Style] = {}
+        style_cache_get = style_cache.get
         combine = Style.combine
 
         def get_current_style() -> Style:
             """Construct current style from stack."""
             style_ids = tuple(sorted(stack))
-            cached_style = style_cache.get(style_ids)
+            cached_style = style_cache_get(style_ids)
             if cached_style is not None:
                 return cached_style
             current_style = combine(style_map[_style_id] for _style_id in style_ids)

--- a/rich/text.py
+++ b/rich/text.py
@@ -875,7 +875,6 @@ class Text(JupyterMixin):
             (offset, offset + len(line))
             for offset, line in zip(divide_offsets, new_lines)
         ]
-
         for span in self._spans:
             line_index = (span.start // average_line_length) % len(line_ranges)
 

--- a/rich/text.py
+++ b/rich/text.py
@@ -1,3 +1,4 @@
+from functools import partial
 import re
 from operator import itemgetter
 from typing import (
@@ -363,7 +364,7 @@ class Text(JupyterMixin):
             offset = len(self) + offset
 
         get_style = console.get_style
-        style = console.get_style(self.style).copy()
+        style = get_style(self.style).copy()
         for start, end, span_style in self._spans:
             if offset >= start and offset < end:
                 style += get_style(span_style)
@@ -507,12 +508,8 @@ class Text(JupyterMixin):
 
         text = self.plain
         null_style = Style()
-
-        def get_style(style: Union[str, Style]) -> Style:
-            return console.get_style(style, default=null_style)
-
         enumerated_spans = list(enumerate(self._spans, 1))
-
+        get_style = partial(console.get_style, default=null_style)
         style_map = {index: get_style(span.style) for index, span in enumerated_spans}
         style_map[0] = get_style(self.style)
 
@@ -529,7 +526,6 @@ class Text(JupyterMixin):
         stack_pop = stack.remove
 
         _Segment = Segment
-
         style_cache: Dict[Tuple[int, ...], Style] = {}
         combine = Style.combine
 

--- a/rich/text.py
+++ b/rich/text.py
@@ -506,7 +506,6 @@ class Text(JupyterMixin):
         """
 
         text = self.plain
-        style_map: Dict[int, Style] = {}
         null_style = Style()
 
         def get_style(style: Union[str, Style]) -> Style:

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -98,7 +98,11 @@ def test_markdown_render():
 
 
 def test_inline_code():
-    markdown = Markdown("inline `import this` code", inline_code_theme="emacs")
+    markdown = Markdown(
+        "inline `import this` code",
+        inline_code_lexer="python",
+        inline_code_theme="emacs",
+    )
     result = render(markdown)
     expected = "inline \x1b[1;38;2;170;34;255;48;2;248;248;248mimport\x1b[0m\x1b[38;2;0;0;0;48;2;248;248;248m \x1b[0m\x1b[1;38;2;0;0;255;48;2;248;248;248mthis\x1b[0m code                                                                             \n"
     print(result)

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -97,6 +97,15 @@ def test_markdown_render():
     assert rendered_markdown == expected
 
 
+def test_inline_code():
+    markdown = Markdown("inline `import this` code", inline_code_theme="emacs")
+    result = render(markdown)
+    expected = "inline \x1b[1;38;2;170;34;255;48;2;248;248;248mimport\x1b[0m\x1b[38;2;0;0;0;48;2;248;248;248m \x1b[0m\x1b[1;38;2;0;0;255;48;2;248;248;248mthis\x1b[0m code                                                                             \n"
+    print(result)
+    print(repr(result))
+    assert result == expected
+
+
 if __name__ == "__main__":
     markdown = Markdown(MARKDOWN)
     rendered = render(markdown)


### PR DESCRIPTION
# WIP

Syntax highlights inline code in Markdown

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
