### PR TITLE
Bump up the total number of `ProgressSample` items.

### DIFF
--- a/rich/progress.py
+++ b/rich/progress.py
@@ -757,7 +757,7 @@ class Progress(JupyterMixin, RenderHook):
             popleft = _progress.popleft
             while _progress and _progress[0].timestamp < old_sample_time:
                 popleft()
-            while len(_progress) > 20:
+            while len(_progress) > 1000:
                 popleft()
             _progress.append(ProgressSample(current_time, update_completed))
 


### PR DESCRIPTION
When working with `rich` download progress bars with `httpx` we were finding the transfer speed jumping around all over the place.

For example, this snippet...

```python
import tempfile
import httpx
import rich.progress

with tempfile.NamedTemporaryFile() as download_file:
    url = "https://speed.hetzner.de/100MB.bin"
    with httpx.stream("GET", url) as response:
        total = int(response.headers["Content-Length"])

        with rich.progress.Progress(
            "[progress.percentage]{task.percentage:>3.0f}%",
            rich.progress.BarColumn(bar_width=None),
            rich.progress.DownloadColumn(),
            rich.progress.TransferSpeedColumn(),
        ) as progress:
            download_task = progress.add_task("Download", total=total)
            for chunk in response.iter_bytes():
                download_file.write(chunk)
                progress.update(download_task, completed=response.num_bytes_downloaded)
```

Was resulting in this...

![rich-progress](https://user-images.githubusercontent.com/647359/93353577-00956500-f834-11ea-8a3b-18b3f4108206.gif)

Have now narrowed down the cause:

When calculating transfer speeds, `rich` stores a ProgressSample every time the progress is updated.
It then averages out the transfer speed based on the progress samples.

The maximum window size of samples that are used is currently set to 30 seconds, or 20 samples, whichever is smaller.
That "maximum of 20 samples" is actually pretty small. (For example reading chunks of 16KB at a download speed of 16MB/s will result in 1000 samples/second)

This PR changes that window size to be 30 seconds, or 1000 samples, whichever is smaller.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other - UX

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
