### PR TITLE
Remove align argument from table Column example

### DIFF
--- a/docs/source/tables.rst
+++ b/docs/source/tables.rst
@@ -59,13 +59,13 @@ You may also add columns by specifying them in the positional arguments of the :
 
     table = Table("Released", "Title", "Box Office", title="Star Wars Movies") 
 
-This allows you to specify the text of the column only. If you want to set other attributes, such as width, style, and alignment, you can add an :class:`~rich.table.Column` class. Here's an example::
+This allows you to specify the text of the column only. If you want to set other attributes, such as width and style, you can add an :class:`~rich.table.Column` class. Here's an example::
 
     from rich.table import Column
     table = Table(
         "Released",
         "Title",
-        Column("Box Office", align="right"),
+        Column(2, header="Box Office", width=20, style="red"),
         title="Star Wars Movies"
     )
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

The example of using `rich.table.Column` in the docs seemed to use an older version of the api with an `align` argument that was no longer supported. I have removed the argument form the example and replaced it with `width` and `style` arguments.

Writing this example made me realize I actually do not know what the mandatory `index` argument does... 😅.

---

Been using your library for the past month on a personal project and it's been a joy to use. Thanks!
