### PR TITLE
use poetry-core to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ jupyter = ["ipywidgets"]
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0a9"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This updates `pyproject.toml` to use `poetry-core` to build instead of the full `poetry` so that `rich` and projects that depend on `rich` will successfully build with `pip install --no-binary :all: rich`: https://github.com/python-poetry/poetry/issues/1975#issuecomment-684773959 . There are currently a couple formulae in macOS Homebrew that are blocked due to this, eg https://github.com/Homebrew/homebrew-core/pull/59954
