### PR TITLE
Use and display panels in rich.columns

### DIFF
--- a/rich/columns.py
+++ b/rich/columns.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":  # pragma: no cover
 
     from rich.panel import Panel
 
-    files = [f"{i} {s}" for i, s in enumerate(sorted(os.listdir()))]
+    files = [Panel(f"{i} {s}") for i, s in enumerate(sorted(os.listdir()))]
     columns = Columns(files, padding=(0, 1), expand=False, equal=False)
     console.print(columns)
     console.rule()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Use and display panels when run python -m rich.columns
