### PR TITLE
Add title_justify and caption_justify options to Table to support lef…

### DIFF
--- a/rich/table.py
+++ b/rich/table.py
@@ -108,6 +108,8 @@ class Table(JupyterMixin):
         border_style (Union[str, Style], optional): Style of the border. Defaults to None.
         title_style (Union[str, Style], optional): Style of the title. Defaults to None.
         caption_style (Union[str, Style], optional): Style of the caption. Defaults to None.
+        title_justify (str, optional): Justification for title. Defaults to "center".
+        caption_justify (str, optional): Justification for caption. Defaults to "center".
     """
 
     columns: List[Column]
@@ -136,6 +138,8 @@ class Table(JupyterMixin):
         border_style: StyleType = None,
         title_style: StyleType = None,
         caption_style: StyleType = None,
+        title_justify: str = "center",
+        caption_justify: str = "center",
     ) -> None:
 
         self.columns: List[Column] = []
@@ -167,6 +171,8 @@ class Table(JupyterMixin):
         self.border_style = border_style
         self.title_style = title_style
         self.caption_style = title_style
+        self.title_justify = title_justify
+        self.caption_justify = caption_justify
         self._row_count = 0
         self.row_styles = list(row_styles or [])
 
@@ -380,23 +386,28 @@ class Table(JupyterMixin):
 
         render_options = options.update(width=table_width)
 
-        def render_annotation(text: TextType, style: StyleType) -> "RenderResult":
+        def render_annotation(
+            text: TextType, style: StyleType, justify: str = "center"
+        ) -> "RenderResult":
             render_text = (
                 console.render_str(text, style=style) if isinstance(text, str) else text
             )
             return console.render(
-                render_text, options=render_options.update(justify="center")
+                render_text, options=render_options.update(justify=justify)
             )
 
         if self.title:
             yield from render_annotation(
-                self.title, style=Style.pick_first(self.title_style, "table.title")
+                self.title,
+                style=Style.pick_first(self.title_style, "table.title"),
+                justify=self.title_justify,
             )
         yield from self._render(console, render_options, widths)
         if self.caption:
             yield from render_annotation(
                 self.caption,
                 style=Style.pick_first(self.caption_style, "table.caption"),
+                justify=self.caption_justify,
             )
 
     def _calculate_column_widths(self, console: "Console", max_width: int) -> List[int]:

--- a/rich/table.py
+++ b/rich/table.py
@@ -387,7 +387,7 @@ class Table(JupyterMixin):
         render_options = options.update(width=table_width)
 
         def render_annotation(
-            text: TextType, style: StyleType, justify: JustifyMethod = "center"
+            text: TextType, style: StyleType, justify: "JustifyMethod" = "center"
         ) -> "RenderResult":
             render_text = (
                 console.render_str(text, style=style) if isinstance(text, str) else text

--- a/rich/table.py
+++ b/rich/table.py
@@ -138,8 +138,8 @@ class Table(JupyterMixin):
         border_style: StyleType = None,
         title_style: StyleType = None,
         caption_style: StyleType = None,
-        title_justify: str = "center",
-        caption_justify: str = "center",
+        title_justify: "JustifyMethod" = "center",
+        caption_justify: "JustifyMethod" = "center",
     ) -> None:
 
         self.columns: List[Column] = []
@@ -387,7 +387,7 @@ class Table(JupyterMixin):
         render_options = options.update(width=table_width)
 
         def render_annotation(
-            text: TextType, style: StyleType, justify: str = "center"
+            text: TextType, style: StyleType, justify: JustifyMethod = "center"
         ) -> "RenderResult":
             render_text = (
                 console.render_str(text, style=style) if isinstance(text, str) else text

--- a/rich/tabulate.py
+++ b/rich/tabulate.py
@@ -6,19 +6,41 @@ from .highlighter import ReprHighlighter
 from .pretty import Pretty
 from .table import Table
 
+_NOT_PROVIDED = object()
 
-def tabulate_mapping(mapping: Mapping, title: str = None) -> Table:
+
+def tabulate_mapping(
+    mapping: Mapping,
+    title: str = None,
+    caption: str = None,
+    title_justify: str = _NOT_PROVIDED,
+    caption_justify: str = _NOT_PROVIDED,
+) -> Table:
     """Generate a simple table from a mapping.
 
     Args:
         mapping (Mapping): A mapping object (e.g. a dict);
         title (str, optional): Optional title to be displayed over the table.
+        caption (str, optional): Optional caption to be displayed below the table.
+        title_justify (str, optional): Optional "right", "center", "left" string indicating title justification
+        caption_justify (str, optional): Optional "right", "center", "left" string indicating caption justification
 
     Returns:
         Table: A table instance which may be rendered by the Console.
     """
-    table = Table(show_header=False, title=title, box=box.ROUNDED, border_style="blue")
+    table = Table(
+        show_header=False,
+        title=title,
+        caption=caption,
+        box=box.ROUNDED,
+        border_style="blue",
+    )
     table.title = title
+    table.caption = caption
+    if title_justify is not _NOT_PROVIDED:
+        table.title_justify = title_justify
+    if caption_justify is not _NOT_PROVIDED:
+        table.caption_justify = caption_justify
     highlighter = ReprHighlighter()
     for key, value in mapping.items():
         table.add_row(
@@ -39,7 +61,14 @@ if __name__ == "__main__":  # pragma: no cover
             "params": [["apple", "orange", "mangoes", "pomelo"], 1.123],
             "id": "194521489",
         }
-        print(tabulate_mapping(locals()))
+        print(
+            tabulate_mapping(
+                locals(),
+                title="locals()",
+                caption="__main__.test",
+                caption_justify="right",
+            )
+        )
 
     print()
     test(20.3423, 3.1427)

--- a/rich/tabulate.py
+++ b/rich/tabulate.py
@@ -50,10 +50,10 @@ def tabulate_mapping(
 
 
 if __name__ == "__main__":  # pragma: no cover
-
+    import itertools
     from rich import print
 
-    def test(foo, bar):
+    def test(foo, bar, tjustify, cjustify):
         list_of_things = [1, 2, 3, None, 4, True, False, "Hello World"]
         dict_of_things = {
             "version": "1.1",
@@ -65,11 +65,15 @@ if __name__ == "__main__":  # pragma: no cover
             tabulate_mapping(
                 locals(),
                 title="locals()",
+                title_justify=tjustify,
                 caption="__main__.test",
-                caption_justify="right",
+                caption_justify=cjustify,
             )
         )
 
-    print()
-    test(20.3423, 3.1427)
+    for title_justify, caption_justify in itertools.product([None, "left", "center", "right"], repeat=2):
+        print()
+        print((title_justify, caption_justify))
+        test(20.3423, 3.1427, title_justify, caption_justify)
+
     print()

--- a/rich/tabulate.py
+++ b/rich/tabulate.py
@@ -50,10 +50,9 @@ def tabulate_mapping(
 
 
 if __name__ == "__main__":  # pragma: no cover
-    import itertools
     from rich import print
 
-    def test(foo, bar, tjustify, cjustify):
+    def test(foo, bar, tjustify=None, cjustify=None):
         list_of_things = [1, 2, 3, None, 4, True, False, "Hello World"]
         dict_of_things = {
             "version": "1.1",
@@ -71,11 +70,6 @@ if __name__ == "__main__":  # pragma: no cover
             )
         )
 
-    for title_justify, caption_justify in itertools.product(
-        [None, "left", "center", "right"], repeat=2
-    ):
-        print()
-        print((title_justify, caption_justify))
-        test(20.3423, 3.1427, title_justify, caption_justify)
-
+    print()
+    test(20.3423, 3.1427, cjustify="right")
     print()

--- a/rich/tabulate.py
+++ b/rich/tabulate.py
@@ -1,20 +1,20 @@
 from collections.abc import Mapping
+from typing import Optional
 
+from rich.console import JustifyMethod
 
 from . import box
 from .highlighter import ReprHighlighter
 from .pretty import Pretty
 from .table import Table
 
-_NOT_PROVIDED = object()
-
 
 def tabulate_mapping(
     mapping: Mapping,
     title: str = None,
     caption: str = None,
-    title_justify: str = _NOT_PROVIDED,
-    caption_justify: str = _NOT_PROVIDED,
+    title_justify: Optional[JustifyMethod] = None,
+    caption_justify: Optional[JustifyMethod] = None,
 ) -> Table:
     """Generate a simple table from a mapping.
 
@@ -37,9 +37,9 @@ def tabulate_mapping(
     )
     table.title = title
     table.caption = caption
-    if title_justify is not _NOT_PROVIDED:
+    if title_justify is not None:
         table.title_justify = title_justify
-    if caption_justify is not _NOT_PROVIDED:
+    if caption_justify is not None:
         table.caption_justify = caption_justify
     highlighter = ReprHighlighter()
     for key, value in mapping.items():

--- a/rich/tabulate.py
+++ b/rich/tabulate.py
@@ -71,7 +71,9 @@ if __name__ == "__main__":  # pragma: no cover
             )
         )
 
-    for title_justify, caption_justify in itertools.product([None, "left", "center", "right"], repeat=2):
+    for title_justify, caption_justify in itertools.product(
+        [None, "left", "center", "right"], repeat=2
+    ):
         print()
         print((title_justify, caption_justify))
         test(20.3423, 3.1427, title_justify, caption_justify)

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -1,3 +1,4 @@
+import itertools
 from rich.style import Style
 from rich.table import _Cell
 from rich.tabulate import tabulate_mapping
@@ -9,3 +10,25 @@ def test_tabulate_mapping():
     assert len(table.columns) == 2
     assert len(table.columns[0]._cells) == 2
     assert len(table.columns[1]._cells) == 2
+
+    # add tests for title and caption justification
+    test_title = "Foo v. Bar"
+    test_caption = "approximate results"
+    for title_justify, caption_justify in itertools.product(
+        [None, "left", "center", "right"], repeat=2
+    ):
+        table = tabulate_mapping(
+            {"foo": "1", "bar": "2"},
+            title=test_title,
+            caption=test_caption,
+            title_justify=title_justify,
+            caption_justify=caption_justify,
+        )
+        expected_title_justify = (
+            title_justify if title_justify is not None else "center"
+        )
+        expected_caption_justify = (
+            caption_justify if caption_justify is not None else "center"
+        )
+        assert expected_title_justify == table.title_justify
+        assert expected_caption_justify == table.caption_justify


### PR DESCRIPTION
…t/center/right justification of title and caption

## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added title_justify and caption_justify arguments to Table constructor, and modified example code in tabulate.py to illustrate.