### PR TITLE
Add fix for not callable attribute "__rich__", "__rich_console__"

### DIFF
--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -59,7 +59,10 @@ def install(
             builtins._ = None  # type: ignore
             console.print(
                 value
-                if hasattr(value, "__rich_console__") or hasattr(value, "__rich__")
+                if hasattr(value, "__rich_console__")
+                and callable(value.__rich_console__)
+                or hasattr(value, "__rich__")
+                and callable(value.__rich__)
                 else Pretty(value, overflow=overflow),
                 crop=crop,
             )


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

addict (https://github.com/mewwts/addict) returns always true when using `hasattr` and does not work with `pritty.install()` in REPL

Error:
```
$ docker run -it --rm ubaumann/automation-ninja
iac@51ec558dbb59:~$ pip install addict -qq
iac@51ec558dbb59:~$ python
Python 3.8.5 (default, Jul 22 2020, 12:28:11)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from addict import Dict
>>> data = Dict()
>>> data["test"] = "test"
>>> data.test
'test'
>>> data
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/iac/.local/lib/python3.8/site-packages/rich/pretty.py", line 60, in display_hook
    console.print(
  File "/home/iac/.local/lib/python3.8/site-packages/rich/console.py", line 894, in print
    extend(render(renderable, render_options))
  File "/home/iac/.local/lib/python3.8/site-packages/rich/console.py", line 595, in render
    renderable = renderable.__rich__()
TypeError: 'Dict' object is not callable
>>>
```

This PR is a quick fix. After the fix it works but the "Dict" does not look pretty.
```
>>> from rich import pretty
>>> pretty.install()
>>> from addict import Dict
>>> data = Dict()
>>> data["Cisco-IOS-XE-native:definition"]["name"] = "Cust_A"
>>> data["Cisco-IOS-XE-native:definition"]["rd"] = "10.3.255.111:100"
>>> data["Cisco-IOS-XE-native:definition"]["route-target"]["import"] = [{"asn-ip": "100:100"}]
>>> data["Cisco-IOS-XE-native:definition"]["route-target"]["export"] = [{"asn-ip": "100:100"}]
>>> data
{'Cisco-IOS-XE-native:definition': {'name': 'Cust_A', 'rd': '10.3.255.111:100', 'route-target': {'import': [{'asn-ip': '100:100'}], 'export': [{'asn-ip': '100:100'}]}}}
>>>
```


I'm happy to discuss this PR
