### PR TITLE
Missing commonmark in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ mypy==0.782
 poetry==1.0.10
 pytest==6.1.0
 pytest-cov==2.10.1
+commonmark==0.9.1


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

When running the tests on MacOS this happened:
```bash
....
make test
...
rich/markdown.py:3: in <module>
    from commonmark.blocks import Parser
E   ModuleNotFoundError: No module named 'commonmark'
```
After installing commonmark all goes nice