### PR TITLE
Fix typo and remove a missing argument in the docstring

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -1413,7 +1413,7 @@ if __name__ == "__main__":  # pragma: no cover
                         "options": [
                             "New York Bulls",
                             "Los Angeles Kings",
-                            "Golden State Warriros",
+                            "Golden State Warriors",
                             "Huston Rocket",
                         ],
                         "answer": "Huston Rocket",

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -271,7 +271,6 @@ class Syntax(JupyterMixin):
         Args:
             path (str): Path to file to highlight.
             encoding (str): Encoding of file.
-            lexer_name (str): Lexer to use (see https://pygments.org/docs/lexers/)
             theme (str, optional): Color theme, aka Pygments style (see https://pygments.org/docs/styles/#getting-a-list-of-available-styles). Defaults to "emacs".
             dedent (bool, optional): Enable stripping of initial whitespace. Defaults to True.
             line_numbers (bool, optional): Enable rendering of line numbers. Defaults to False.


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fix typo and remove a missing argument in the docstring