### PR TITLE
Fix rich.print for dict-inherited objects

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -893,7 +893,11 @@ class Console:
                 del text[:]
 
         for renderable in objects:
-            rich_cast = getattr(renderable, "__rich__", None)
+            try:
+                rich_cast = getattr(renderable, "__rich__", None)
+            except (KeyError, AttributeError):
+                rich_cast = renderable.get("__rich__", None)
+
             if rich_cast:
                 renderable = rich_cast()
             if isinstance(renderable, str):
@@ -905,6 +909,8 @@ class Console:
                         highlighter=_highlighter,
                     )
                 )
+            elif isinstance(renderable, dict):
+                append_text(_highlighter(str(renderable)))
             elif isinstance(renderable, ConsoleRenderable):
                 check_text()
                 append(renderable)


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
To fix issue #351 (Key error __rich__). Accounted for inherited dict types that cannot be accessed by getattr().
