### PR TITLE
Fixed pip editable install

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,6 +31,9 @@ jobs:
         run: |
           pip install .
           python -m pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
+      - name: Check if pip editable installs still work
+        run: |
+          pip install -e .
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v1.0.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,8 @@ jupyter = ["ipywidgets"]
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = [
+    "poetry-core>=1.0.0",
+    "setuptools",  # keep it here or "pip install -e" would fail
+    ]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Fixes: #346

## Type of changes

- [x] Bug fix

## Description

This should bring make editable installs with pip working again. It also includes a minimal CI testing of editable installs, just to avoid future regression.