### PR TITLE
Avoid codecov spam

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Current configuration of codecov does SPAM not only github user interface but also our inboxes.

This disables the codecov comment, but not the tool itself. The tool still runs and reports using check API, being visible like any other github action.

See: https://docs.codecov.io/docs/pull-request-comments