### PR TITLE
POC: Validates package installation

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,6 +21,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           poetry install
+          # Verify that rich package can really be found by current python
+          cd tools
+          python -c "import rich; print(rich.__file__)"
       - name: Format check with black
         run: |
           make format-check


### PR DESCRIPTION
This PR should prove that "poetry install" command does not work in absence of an **activated** virtualenv.

Documentation mentions creation of virtualenv but it does not mention that it needs to be activated or poetry will not really have any usable effect.