### PR TITLE
Additional tests for `measure.py`, `table.py`, `padding.py` and `containers.py`, as well as some possible code fixes

### DIFF
--- a/rich/containers.py
+++ b/rich/containers.py
@@ -148,7 +148,6 @@ class Lines:
                         num_spaces += 1
                         index = (index + 1) % len(spaces)
                 tokens: List[Text] = []
-                index = 0
                 for index, (word, next_word) in enumerate(
                     zip_longest(words, words[1:])
                 ):
@@ -161,5 +160,4 @@ class Lines:
                             next_style = next_word.get_style_at_offset(console, 0)
                             space_style = style if style == next_style else line.style
                         tokens.append(Text(" " * spaces[index], style=space_style))
-                    index += 1
                 self[line_index] = Text("").join(tokens)

--- a/rich/containers.py
+++ b/rich/containers.py
@@ -153,11 +153,8 @@ class Lines:
                 ):
                     tokens.append(word)
                     if index < len(spaces):
-                        if next_word is None:
-                            space_style = Style.null()
-                        else:
-                            style = word.get_style_at_offset(console, -1)
-                            next_style = next_word.get_style_at_offset(console, 0)
-                            space_style = style if style == next_style else line.style
+                        style = word.get_style_at_offset(console, -1)
+                        next_style = next_word.get_style_at_offset(console, 0)
+                        space_style = style if style == next_style else line.style
                         tokens.append(Text(" " * spaces[index], style=space_style))
                 self[line_index] = Text("").join(tokens)

--- a/rich/table.py
+++ b/rich/table.py
@@ -488,13 +488,10 @@ class Table(JupyterMixin):
                 max_column = max(
                     width for width, allow_wrap in zip(widths, wrapable) if allow_wrap
                 )
-                try:
-                    second_max_column = max(
-                        width if allow_wrap and width != max_column else 0
-                        for width, allow_wrap in zip(widths, wrapable)
-                    )
-                except ValueError:
-                    second_max_column = 0
+                second_max_column = max(
+                    width if allow_wrap and width != max_column else 0
+                    for width, allow_wrap in zip(widths, wrapable)
+                )
                 column_difference = max_column - second_max_column
                 ratios = [
                     (1 if (width == max_column and allow_wrap) else 0)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -45,7 +45,7 @@ def test_lines_justify():
     lines1.justify(console, 10, justify="right")
     assert lines1._lines == [Text("       foo"), Text("      test")]
 
-    lines2 = Lines([Text("foo  bar"), Text("test")])
+    lines2 = Lines([Text("foo bar"), Text("test")])
     lines2.justify(console, 7, justify="full")
     assert lines2._lines == [
         Text(

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,6 +1,7 @@
 from rich.console import Console
 from rich.containers import Lines, Renderables
-from rich.text import Text
+from rich.text import Span, Text
+from rich.style import Style
 
 
 def test_renderables_measure():
@@ -32,3 +33,24 @@ def test_lines_rich_console():
 
     result = list(lines.__rich_console__(console, console.options))
     assert result == [Text("foo")]
+
+
+def test_lines_justify():
+    console = Console()
+    lines1 = Lines([Text("foo"), Text("test")])
+    lines1.justify(console, 10, justify="left")
+    assert lines1._lines == [Text("foo       "), Text("test      ")]
+    lines1.justify(console, 10, justify="center")
+    assert lines1._lines == [Text("   foo    "), Text("   test   ")]
+    lines1.justify(console, 10, justify="right")
+    assert lines1._lines == [Text("       foo"), Text("      test")]
+
+    lines2 = Lines([Text("foo  bar"), Text("test")])
+    lines2.justify(console, 7, justify="full")
+    assert lines2._lines == [
+        Text(
+            "foo bar",
+            spans=[Span(0, 3, ""), Span(3, 4, Style.parse("none")), Span(4, 7, "")],
+        ),
+        Text("test"),
+    ]

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -3,7 +3,7 @@ import pytest
 
 from rich.errors import NotRenderableError
 from rich.console import Console
-from rich.measure import Measurement
+from rich.measure import Measurement, measure_renderables
 
 
 def test_span():
@@ -26,5 +26,8 @@ def test_null_get():
     assert Measurement.get(Console(), None, -1) == Measurement(0, 0)
 
 
-if __name__ == "__main__":
-    test_null_get()
+def test_measure_renderables():
+    # Test measure_renderables returning a null Measurement object
+    assert measure_renderables(Console(), None, None) == Measurement(0, 0)
+    # Test measure_renderables returning a valid Measurement object
+    assert measure_renderables(Console(width=1), ["test"], 1) == Measurement(1, 1)

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -17,3 +17,14 @@ def test_no_renderable():
 
     with pytest.raises(NotRenderableError):
         Measurement.get(console, None, console.width)
+
+
+def test_null_get():
+    # Test negative console.width passed into get method
+    assert Measurement.get(Console(width=-1), None) == Measurement(0, 0)
+    # Test negative max_width passed into get method
+    assert Measurement.get(Console(), None, -1) == Measurement(0, 0)
+
+
+if __name__ == "__main__":
+    test_null_get()

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,6 +1,9 @@
 import pytest
 
 from rich.padding import Padding
+from rich.console import Console, ConsoleOptions
+from rich.style import Style
+from rich.segment import Segment
 
 
 def test_repr():
@@ -9,7 +12,11 @@ def test_repr():
 
 
 def test_indent():
-    assert Padding.indent("test", 4).left == 4
+    indent_result = Padding.indent("test", 4)
+    assert indent_result.top == 0
+    assert indent_result.right == 0
+    assert indent_result.bottom == 0
+    assert indent_result.left == 4
 
 
 def test_unpack():
@@ -19,3 +26,22 @@ def test_unpack():
     assert Padding.unpack((3, 4, 5, 6)) == (3, 4, 5, 6)
     with pytest.raises(ValueError):
         Padding.unpack((1, 2, 3))
+
+
+def test_rich_console():
+    renderable = "test renderable"
+    style = Style(color="red")
+    options = ConsoleOptions(
+        min_width=10, max_width=20, is_terminal=False, encoding="utf-8"
+    )
+
+    expected_outputs = [
+        Segment(renderable, style=style),
+        Segment(" " * (20 - len(renderable)), style=style),
+        Segment("\n", style=None),
+    ]
+    padding_generator = Padding(renderable, style=style).__rich_console__(
+        Console(), options
+    )
+    for output, expected in zip(padding_generator, expected_outputs):
+        assert output == expected

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -8,6 +8,10 @@ def test_repr():
     assert isinstance(repr(padding), str)
 
 
+def test_indent():
+    assert Padding.indent("test", 4).left == 4
+
+
 def test_unpack():
     assert Padding.unpack(3) == (3, 3, 3, 3)
     assert Padding.unpack((3,)) == (3, 3, 3, 3)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -7,7 +7,7 @@ import pytest
 from rich import errors
 from rich.console import Console
 from rich.measure import Measurement
-from rich.table import Table
+from rich.table import Table, Column
 from rich.text import Text
 
 
@@ -90,6 +90,18 @@ def test_not_renderable():
     table = Table()
     with pytest.raises(errors.NotRenderableError):
         table.add_row(Foo())
+
+
+def test_append_column():
+    header_names = ["header1", "header2", "header3"]
+    test_columns = [
+        Column(_index=index, header=header) for index, header in enumerate(header_names)
+    ]
+
+    # Test appending of strings for header names
+    assert Table("header1", "header2", "header3").columns == test_columns
+    # Test directly passing a Table Column objects
+    assert Table(*test_columns).columns == test_columns
 
 
 if __name__ == "__main__":

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -99,9 +99,16 @@ def test_append_column():
     ]
 
     # Test appending of strings for header names
-    assert Table("header1", "header2", "header3").columns == test_columns
+    assert Table(*header_names).columns == test_columns
     # Test directly passing a Table Column objects
     assert Table(*test_columns).columns == test_columns
+
+
+def test_rich_measure():
+    # Check __rich_measure__() for a negative width passed as an argument
+    assert Table().__rich_measure__(Console(), -1) == Measurement(0, 0)
+    # Check __rich_measure__() for a negative Table.width attribute
+    assert Table(width=-1).__rich_measure__(Console(), 1) == Measurement(0, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -110,9 +110,9 @@ def test_rich_measure():
         Console(), -1
     ) == Measurement(0, 0)
     # Check __rich_measure__() for a negative Table.width attribute
-    assert Table("test_header", width=-1).__rich_measure__(
-        Console(), 1
-    ) == Measurement(0, 0)
+    assert Table("test_header", width=-1).__rich_measure__(Console(), 1) == Measurement(
+        0, 0
+    )
     # Check __rich_measure__() for a positive width passed as an argument
     assert Table("test_header", width=None).__rich_measure__(
         Console(), 10

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -92,7 +92,7 @@ def test_not_renderable():
         table.add_row(Foo())
 
 
-def test_append_column():
+def test_init_append_column():
     header_names = ["header1", "header2", "header3"]
     test_columns = [
         Column(_index=index, header=header) for index, header in enumerate(header_names)
@@ -106,9 +106,21 @@ def test_append_column():
 
 def test_rich_measure():
     # Check __rich_measure__() for a negative width passed as an argument
-    assert Table().__rich_measure__(Console(), -1) == Measurement(0, 0)
+    assert Table("test_header", width=None).__rich_measure__(
+        Console(), -1
+    ) == Measurement(0, 0)
     # Check __rich_measure__() for a negative Table.width attribute
-    assert Table(width=-1).__rich_measure__(Console(), 1) == Measurement(0, 0)
+    assert Table("test_header", width=-1).__rich_measure__(
+        Console(), 1
+    ) == Measurement(0, 0)
+    # Check __rich_measure__() for a positive width passed as an argument
+    assert Table("test_header", width=None).__rich_measure__(
+        Console(), 10
+    ) == Measurement(10, 10)
+    # Check __rich_measure__() for a positive Table.width attribute
+    assert Table("test_header", width=10).__rich_measure__(
+        Console(), -1
+    ) == Measurement(10, 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Type of changes

- [x] Bug fix (See description under `table.py` and `containers.py`)
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Some additional tests in response to #37 for the following files:
* `measure.py`
    * `test_null_get`: Checks for cases where `Measurement.get()` should return `Measurement(0, 0)`
    * `test_measure_renderables`: Tests that `measure_renderables` returns the correct `Measurement` object 
* `table.py`
    * `test_append_column`: Checks whether headers are correctly added to `self.columns` in `Table`. I'm not too sure if this test is meaningful enough though.
    * `test_rich_measure`: Checks whether the `__rich_measure__` method of `Table` returns the correct `Measurement` object for several cases
    * Tried to add a test for lines 496-497, however I can't engineer a case where the code in `try` would raise a `ValueError`:
        ```python
        try:
            second_max_column = max(
                width if allow_wrap and width != max_column else 0
                for width, allow_wrap in zip(widths, wrapable)
            )
        except ValueError:
            second_max_column = 0
        ```
        Afaik, a `ValueError` would only be thrown by `max()` in a situation where an empty sequence is passed to it. But for us to get to the `try/except`, both `widths` and `wrapable` would have to be valid, which would in turn generate valid arguments for the `max()` function. Because of this, I'm not convinced a `try/except` for a `ValueError` is necessary in the function and hence removed it from the method..
* `padding.py`
    * `test_indent`: Tests the `indent` method of `Padding`. Also not sure if this test is meaningful enough.
    * `test_rich_console`: Tests the output of the `__rich_console__` method
* `containers.py`
    * `test_lines_justify` Tests the outputs of the `justify` method for `Lines`
    * It seems the `if next_word is None:` condition in line 156 of `conatiners.py` will never be triggered as `next_word` will only be `None` if `index == len(spaces)`, however the preceeding `if index < len(spaces):`  skips the execution of the `if next_word is None:` condition.
    ```python
    if index < len(spaces): 
            if next_word is None: # Only occurs if index==len(spaces)?
                space_style = Style.null()
            else:
                style = word.get_style_at_offset(console, -1)
                next_style = next_word.get_style_at_offset(console, 0)
                space_style = style if style == next_style else line.style
    ```
    Propose removing the if/else like so and have made a corresponding change in the PR:
    ```python
    if index < len(spaces): 
            style = word.get_style_at_offset(console, -1)
            next_style = next_word.get_style_at_offset(console, 0)
            space_style = style if style == next_style else line.style
    ```
Looking forward to your feedback!