### PR TITLE
Adopts pre-commit for running already existing linters

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,17 +17,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+      - name: Install system packages
+        run: sudo apt-get install libxml2-utils libxslt1-dev
+        if: matrix.os == 'ubuntu-latest'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           poetry install
-      - name: Format check with black
-        run: |
-          make format-check
-      - name: Typecheck with mypy
-        run: |
-          make typecheck
+      - name: Perform linting
+        # same as local 'make lint' but faster due to caching
+        uses: pre-commit/action@v2.0.0
       - name: Test with pytest
         run: |
           pip install .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# to bump linters just run: pre-commit autoupdate
+repos:
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.790
+    hooks:
+    - id: mypy
+      # empty args needed in order to match mypy cli behavior
+      pass_filenames: false
+      args: ["--ignore-missing-imports", "--warn-unreachable", "--html-report", "mypy_report"]
+      entry: mypy -p rich
+      additional_dependencies:
+        - lxml  # html report requires it

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 test:
 	pytest --cov-report term-missing --cov=rich tests/ -vv
-format-check:
-	black --check .
+lint:
+	pre-commit run -a
 format:
-	black .
+	pre-commit run black -a
 typecheck:
-	mypy -p rich --ignore-missing-imports --warn-unreachable
+	pre-commit run mypy -a
 typecheck-report:
 	mypy -p rich --ignore-missing-imports --warn-unreachable --html-report mypy_report
 .PHONY: docs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ mypy==0.790
 poetry==1.1.4
 pytest==6.1.2
 pytest-cov==2.10.1
+pre-commit==2.7.1


### PR DESCRIPTION
## Type of changes

- [x] Tests

## Description

- Adds "make lint" as generic command
- Linters are removed from requirements-dev.txt as they are now managed by pre-commit itself. This avoids potential conflicts between linters as pre-commit installs each linter on its own
  environment.
- To be reviewed after https://github.com/willmcgugan/rich/pull/348 is merged as it builds on top of it
- Please note that while this change does not bring any apparent new feature, it does enable us to add and manage extra linters (like flake8 or pylint) much easier.

Fixes: #355