### PR TITLE
Don't rely on set ordering for test data

### DIFF
--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -18,7 +18,7 @@ def test_install():
 
 def test_pretty():
     test = {
-        "foo": [1, 2, 3, {4, 5, 6, (7, 8, 9)}, {}],
+        "foo": [1, 2, 3, (4, 5, {6}, 7, 8, {9}), {}],
         "bar": {"egg": "baz", "words": ["Hello World"] * 10},
         False: "foo",
         True: "",
@@ -28,7 +28,7 @@ def test_pretty():
     result = pretty_repr(test, max_width=80)
     print(result)
     print(repr(result))
-    expected = "{\n    'foo': [1, 2, 3, {(7, 8, 9), 4, 5, 6}, {}],\n    'bar': {\n        'egg': 'baz',\n        'words': [\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World'\n        ]\n    },\n    False: 'foo',\n    True: '',\n    'text': ('Hello World', 'foo bar baz egg')\n}"
+    expected = "{\n    'foo': [1, 2, 3, (4, 5, {6}, 7, 8, {9}), {}],\n    'bar': {\n        'egg': 'baz',\n        'words': [\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World',\n            'Hello World'\n        ]\n    },\n    False: 'foo',\n    True: '',\n    'text': ('Hello World', 'foo bar baz egg')\n}"
     assert result == expected
 
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #255.
Ensures sets in `tests/test_pretty.py::test_pretty` only contain one element. The ordering of sets is non-deterministic and can change between platforms. Having multiple items in the set causes the test to fail on some platforms.
