### PR TITLE
Allow level name of `RichHandler` to be customized

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@ The following people have contributed to the development of Rich:
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Hedy Li](https://github.com/hedythedev)
 - [Will McGugan](https://github.com/willmcgugan)
+- [Panwen Wang](https://github.com/pwwang)

--- a/rich/_log_render.py
+++ b/rich/_log_render.py
@@ -13,7 +13,7 @@ class LogRender:
     def __init__(
         self,
         show_time: bool = True,
-        show_level: bool = False,
+        show_level: Union[int, bool] = False,
         show_path: bool = True,
         time_format: str = "[%x %X]",
     ) -> None:
@@ -42,7 +42,7 @@ class LogRender:
         if self.show_time:
             output.add_column(style="log.time")
         if self.show_level:
-            output.add_column(style="log.level", width=8)
+            output.add_column(style="log.level", width=self.show_level)
         output.add_column(ratio=1, style="log.message", overflow="fold")
         if self.show_path and path:
             output.add_column(style="log.path")

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":  # pragma: no cover
         level="NOTSET",
         format=FORMAT,
         datefmt="[%X]",
-        handlers=[RichHandler(rich_tracebacks=True, show_level=lambda level: level[:4])],
+        handlers=[RichHandler(rich_tracebacks=True)],
     )
     log = logging.getLogger("rich")
 

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -71,11 +71,15 @@ class RichHandler(Handler):
         self.console = console or get_console()
         self.highlighter = highlighter or self.HIGHLIGHTER_CLASS()
         self._log_render = LogRender(
-            show_time=show_time, 
-            show_level=(False if show_level is False
-                        else 8 if show_level is True
-                        else len(show_level('CRITICAL'))), 
-            show_path=show_path
+            show_time=show_time,
+            show_level=(
+                False
+                if show_level is False
+                else len(show_level("CRITICAL"))
+                if callable(show_level)
+                else 8
+            ),
+            show_path=show_path,
         )
         self.show_level = show_level
         self.enable_link_path = enable_link_path
@@ -96,10 +100,12 @@ class RichHandler(Handler):
 
         level = Text()
         if self.show_level:
-            level.append(self.show_level(record.levelname)
-                         if callable(self.show_level)
-                         else record.levelname, 
-                         log_style)
+            level.append(
+                self.show_level(record.levelname)
+                if callable(self.show_level)
+                else record.levelname,
+                log_style,
+            )
 
         traceback = None
         if (

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -74,6 +74,27 @@ def test_exception_with_extra_lines():
     assert "division by zero" in render
 
 
+def test_custom_levelname():
+    console = Console(
+        file=io.StringIO(), force_terminal=True, color_system="truecolor"
+    )
+    handler_custom_levelname = RichHandler(
+        console=console,
+        show_level=lambda level: level[0]
+    )
+    log.addHandler(handler_custom_levelname)
+
+    log.error('')
+    log.warning('')
+
+    render = handler_custom_levelname.console.file.getvalue()
+    print(render)
+
+    assert "E" in render and "ERROR" not in render
+    assert "W" in render and "WARNING" not in render
+
+
+
 if __name__ == "__main__":
     render = make_log()
     print(render)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -75,24 +75,20 @@ def test_exception_with_extra_lines():
 
 
 def test_custom_levelname():
-    console = Console(
-        file=io.StringIO(), force_terminal=True, color_system="truecolor"
-    )
+    console = Console(file=io.StringIO(), force_terminal=True, color_system="truecolor")
     handler_custom_levelname = RichHandler(
-        console=console,
-        show_level=lambda level: level[0]
+        console=console, show_level=lambda level: level[0]
     )
     log.addHandler(handler_custom_levelname)
 
-    log.error('')
-    log.warning('')
+    log.error("")
+    log.warning("")
 
     render = handler_custom_levelname.console.file.getvalue()
     print(render)
 
     assert "E" in render and "ERROR" not in render
     assert "W" in render and "WARNING" not in render
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Allow level name of `RichHandler` to be customized

```python
import logging
from rich.logging import RichHandler

logger = logging.getLogger('rich')
logger.addHanlder(RichHandler(show_level=lambda level: level[:1]))

logger.info('info')
logger.warning('warning')
```
```
[10/23/20 20:14:18] I info
                    W warning
```

`show_level` argument of `RichHandler` now can receive a function to format or transform the level name of the record.
This function should return a fixed width of all level names.
