### PR TITLE
Allow subclassing RichHandler

### DIFF
--- a/rich/_log_render.py
+++ b/rich/_log_render.py
@@ -16,11 +16,13 @@ class LogRender:
         show_level: bool = False,
         show_path: bool = True,
         time_format: str = "[%x %X]",
+        level_width: int = 8,
     ) -> None:
         self.show_time = show_time
         self.show_level = show_level
         self.show_path = show_path
         self.time_format = time_format
+        self.level_width = level_width
         self._last_time: Optional[str] = None
 
     def __call__(
@@ -42,7 +44,7 @@ class LogRender:
         if self.show_time:
             output.add_column(style="log.time")
         if self.show_level:
-            output.add_column(style="log.level", width=8)
+            output.add_column(style="log.level", width=self.level_width)
         output.add_column(ratio=1, style="log.message", overflow="fold")
         if self.show_path and path:
             output.add_column(style="log.path")

--- a/rich/_log_render.py
+++ b/rich/_log_render.py
@@ -10,6 +10,16 @@ if TYPE_CHECKING:
 
 
 class LogRender:
+    """A helper class to render log records.
+
+    Args:
+        show_time (bool): Show a column for the time. Defaults to True.
+        show_level (bool): Show a column for the level. Defaults to True.
+        show_path (bool): Show the path to the original log call. Defaults to True.
+        time_format (str): The time format for the log time. Defaults to "[%x %X]".
+        level_width (int): The width of the level column. Defaults to 8.
+    """
+
     def __init__(
         self,
         show_time: bool = True,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -74,6 +74,35 @@ def test_exception_with_extra_lines():
     assert "division by zero" in render
 
 
+def test_custom_level_name():
+    console = Console(file=io.StringIO())
+
+    class MyHandler(RichHandler):
+        levels = {
+            logging.WARNING: "WARN",
+            logging.ERROR: "ERR",
+            # custom level
+            9: "FOO",
+        }
+        level_width = 4
+
+    handler_custom_levels = MyHandler(console=console)
+    log.addHandler(handler_custom_levels)
+
+    log.warning("Deprecated!")
+    log.error("Access denied!")
+    log._log(9, "Custom log level", ())
+    log.critical("Longer name")
+
+    render = handler_custom_levels.console.file.getvalue()
+    print(render)
+
+    assert "WARN Deprecated!" in render
+    assert "ERR  Access denied!" in render
+    assert "FOO  Custom log level" in render
+    assert "CRI… Longer name" in render
+
+
 if __name__ == "__main__":
     render = make_log()
     print(render)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -82,16 +82,17 @@ def test_custom_level_name():
             logging.WARNING: "WARN",
             logging.ERROR: "ERR",
             # custom level
-            9: "FOO",
+            11: "FOO",
         }
         level_width = 4
 
     handler_custom_levels = MyHandler(console=console)
     log.addHandler(handler_custom_levels)
+    log.setLevel(logging.DEBUG)
 
     log.warning("Deprecated!")
     log.error("Access denied!")
-    log._log(9, "Custom log level", ())
+    log.log(11, "Custom log level")
     log.critical("Longer name")
 
     render = handler_custom_levels.console.file.getvalue()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Based on the discussion in #403 

Now `RichHandler` can be subclassed with two variables `levels` and `level_width` optionally.

`levels` is a dictionary with level numbers as keys and level names as values. One can rename a level with an existing level number, or add a new level number and name.

`level_width` is to define the width in the level column. If not given, the maximum with of all levels (including the ones defined by `level`) will be used. If the level name is longer than `level_width`, it will be cut.

Example:
```python
import logging
from rich.logging import RichHandler

class MyHandler(RichHandler):
    levels = { 
        logging.WARNING: 'WARN',
        logging.ERROR: 'ERR',
        logging.DEBUG: 'DBG',
        9: 'FOO'
    }
    # If this is not defined, 8 will be used, since CRITICAL is the longest name
    level_width = 4 

logger = logging.getLogger('rich_level_rename')
logger.addHandler(MyHandler(show_path=False))
logger.setLevel(logging.DEBUG)

logger.info('An info message')
logger.warning('A warning message')
logger.error('An error message')
logger.debug('A debug message')
logger._log(9, 'A custom message', ())
logger.critical('A critical message')
```

![image](https://user-images.githubusercontent.com/1188067/97100342-9bf9d100-164f-11eb-9804-a84d29c1618d.png)





