### PR TITLE
Document use of rich by molecule and ansible-lint projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,4 +328,6 @@ Here are a few projects using Rich:
   Automagically synchronize subtitles with video.
 - [tryolabs/norfair](https://github.com/tryolabs/norfair)
   Lightweight Python library for adding real-time 2D object tracking to any detector.
+- [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint checks playbooks for practices and behaviour that could potentially be improved
+- [ansible-community/molecule](https://github.com/ansible-community/molecule) Ansible Molecule testing framework
 - +[Many more](https://github.com/willmcgugan/rich/network/dependents)!


### PR DESCRIPTION
Documents use of rich by molecule and ansible-lint, two popular command line tools with over 2k github stars.

## Type of changes

- [x] Documentation / docstrings

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I am totally ok if you refuse this PR as sooner or later you will have to stop pubishing list of users on the README. I seen this becoming a real issue with cookiecutter project. Still, I do think that listing few high-profile projects could help advertise rich to others.
