### PR TITLE
Make TimeRemainingColumn in progress.track optional 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tracebacks_show_locals parameter to RichHandler
 - Applied dim=True to indent guide styles
 - Added max_string to Pretty
+- Added show_remaining_time parameter to progress.track
 
 ## [9.1.0] - 2020-10-23
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,5 +5,6 @@ The following people have contributed to the development of Rich:
 <!-- Add your name below, sort alphabetically by surname. Link to Github profile / your home page. -->
 
 - [Oleksis Fraga](https://github.com/oleksis)
+- [Evgeny Kovalchuk](https://github.com/Senpos)
 - [Hedy Li](https://github.com/hedythedev)
 - [Will McGugan](https://github.com/willmcgugan)

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -100,6 +100,7 @@ def track(
     finished_style: StyleType = "bar.finished",
     pulse_style: StyleType = "bar.pulse",
     update_period: float = 0.1,
+    show_remaining_time: bool = True,
 ) -> Iterable[ProgressType]:
     """Track progress by iterating over a sequence.
 
@@ -133,9 +134,12 @@ def track(
                 pulse_style=pulse_style,
             ),
             TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-            TimeRemainingColumn(),
         )
     )
+
+    if show_remaining_time:
+        columns.append(TimeRemainingColumn())
+
     progress = Progress(
         *columns,
         auto_refresh=auto_refresh,

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -117,6 +117,7 @@ def track(
         finished_style (StyleType, optional): Style for a finished bar. Defaults to "bar.done".
         pulse_style (StyleType, optional): Style for pulsing bars. Defaults to "bar.pulse".
         update_period (float, optional): Minimum time (in seconds) between calls to update(). Defaults to 0.1.
+        show_remaining_time (bool, optional): Show a column with the estimated time remaining. Defaults to True.
     Returns:
         Iterable[ProgressType]: An iterable of the values in the sequence.
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

As a convenience function, `rich.progress.track` allows to create progress bars easily with great defaults, however, I often find myself working with tasks where we can't really estimate the time remaining, so I wish I could have an opportunity to disable `TimeRemainingColumn` to not confuse users.

**Yes**, I can always build a `rich.progress.Progress` object myself with all the columns I need, but IMO it is pretty common use-case so it is worth it to add an additional parameter like `show_remaining_time` to the `rich.progress.track` function. :)

As it should be backwards compatible, the default value is `True` (time remaining will be shown) and the parameter is added to the very end, because it is not kwargs-only one, so we don't want to break code where people pass parameters positionally.

Please, let me know if you are interested in this feature or if I need to do anything extra to make it useful.

I have added this parameter the docstring and checked that all the tests pass.

I also ran `make format-check`, it found a problem with `rich/tests/test_pretty.py`, but I did not even touch it, so it might be a glitch. 😅

If you need this functionality to have an extra test, please, let me know. I will also need some guidance on how to do that.
I believe, I might need to duplicate+modify `test_track` test and call it `test_track_without_time_remaining`.

P. S. Thanks for creating the library, it is so convenient to use. 🎉
