### PR TITLE
Strip ANSI escapes when producing HTML

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -1404,8 +1404,15 @@ class Console:
         _theme = theme or DEFAULT_TERMINAL_THEME
         stylesheet = ""
 
+        def strip_ansi_escape(text: str) -> str:
+            """Remove all ANSI escapes from string or bytes."""
+            return re.sub(r"\x1b[^m]*m", "", data)
+
         def escape(text: str) -> str:
             """Escape html."""
+            # As HTML will never render ANSI text, we better clean it until
+            # we can use a converter.
+            text = strip_ansi_escape(text)
             return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
         render_code_format = CONSOLE_HTML_FORMAT if code_format is None else code_format


### PR DESCRIPTION
In order to avoid seeing ANSI garbage produced by other tools, we now strip ANSI escapes inside html_report(), as this will mare the output more readable.

## Type of changes

- [x] Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
