### PR TITLE
Fix translation of Korean texts.

### DIFF
--- a/rich/__main__.py
+++ b/rich/__main__.py
@@ -113,7 +113,7 @@ def make_test_card() -> Table:
             box=box.DOUBLE_EDGE,
         ),
         Panel(
-            Text("도서관은 중국어, 일본어 및 한국어 텍스트를 지원합니다", overflow="fold"),
+            Text("이 라이브러리는 중국어, 일본어 및 한국어 텍스트를 지원합니다", overflow="fold"),
             expand=False,
             border_style="Red",
             box=box.DOUBLE_EDGE,
@@ -121,7 +121,7 @@ def make_test_card() -> Table:
     )
     table.add_row(
         "Asian languages",
-        ":flag_for_china:  该库支持中文，日文和韩文文本！\n:flag_for_japan:  ライブラリは中国語、日本語、韓国語のテキストをサポートしています\n:flag_for_south_korea:  도서관은 중국어, 일본어 및 한국어 텍스트를 지원합니다",
+        ":flag_for_china:  该库支持中文，日文和韩文文本！\n:flag_for_japan:  ライブラリは中国語、日本語、韓国語のテキストをサポートしています\n:flag_for_south_korea:  이 라이브러리는 중국어, 일본어 및 한국어 텍스트를 지원합니다",
     )
 
     markup_example = (


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

- I have changed the Korean text to a more appropriate translation, assume that the original English text was "The library supports Chinese, Japanese, and Korean texts".
- I have not run the formatter or updated CHANGELOG, since it is a really minor change.
- I think that [imgs/features.png](https://github.com/willmcgugan/rich/blob/master/imgs/features.png) should reflect the change, but I do not know how to do it. Could you help me with this?