### PR TITLE
resolve pyoxidizer compatible issue

### DIFF
--- a/rich/jupyter.py
+++ b/rich/jupyter.py
@@ -1,7 +1,7 @@
 from typing import Iterable, List, TYPE_CHECKING
 
 # from .console import Console as BaseConsole
-from .__init__ import get_console
+from . import get_console
 from .segment import Segment
 from .terminal_theme import DEFAULT_TERMINAL_THEME
 

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -20,7 +20,7 @@ from typing import (
 from rich.highlighter import ReprHighlighter
 
 from .abc import RichRenderable
-from .__init__ import get_console
+from . import get_console
 from ._pick import pick_bool
 from .cells import cell_len
 from .highlighter import ReprHighlighter

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -1,6 +1,6 @@
 from typing import IO, Any, Generic, List, Optional, TextIO, TypeVar, Union, overload
 
-from .__init__ import get_console
+from . import get_console
 from .console import Console
 from .text import Text, TextType
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description
Hi, 

The error occurs when using pyoxidizer to packaging python application depends on rich. It seems below import can't be handled in pyoxidizer:
```
from .__init__ import something
```

The related pyoxidizer issue: https://github.com/indygreg/PyOxidizer/issues/317
