### PR TITLE
Revert traceback console width to 100.

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -157,7 +157,7 @@ class Traceback:
     def __init__(
         self,
         trace: Trace = None,
-        width: Optional[int] = 88,
+        width: Optional[int] = 100,
         extra_lines: int = 3,
         theme: Optional[str] = None,
         word_wrap: bool = False,


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate. <- Seems unnecessary for a change this small.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

#493 I fix this. Just one change.

Looking in the blame, seems this was previously called code_width and was set to 88. This updates the Traceback Class to match the same parameters as the install() function.