### PR TITLE
fix typo in docs

### DIFF
--- a/docs/source/live.rst
+++ b/docs/source/live.rst
@@ -138,7 +138,7 @@ The Live class will create an internal Console object which you can access via `
     table.add_column("Description")
     table.add_column("Level")
 
-    with Live(table, refresh_per_second=4):  # update 4 times a second to feel fluid
+    with Live(table, refresh_per_second=4) as live:  # update 4 times a second to feel fluid
         for row in range(12):
             live.console.print("Working on row #{row}")
             time.sleep(0.4)

--- a/docs/source/tables.rst
+++ b/docs/source/tables.rst
@@ -55,9 +55,9 @@ The :class:`~rich.table.Table` class offers a number of configuration options to
 Adding columns
 ~~~~~~~~~~~~~~
 
-You may also add columns by specifying them in the positional arguments of the :class:`~rich.table.Table` constructor. For example, we could construct a table with three columns like this:: 
+You may also add columns by specifying them in the positional arguments of the :class:`~rich.table.Table` constructor. For example, we could construct a table with three columns like this::
 
-    table = Table("Released", "Title", "Box Office", title="Star Wars Movies") 
+    table = Table("Released", "Title", "Box Office", title="Star Wars Movies")
 
 This allows you to specify the text of the column only. If you want to set other attributes, such as width and style, you can add an :class:`~rich.table.Column` class. Here's an example::
 
@@ -65,7 +65,7 @@ This allows you to specify the text of the column only. If you want to set other
     table = Table(
         "Released",
         "Title",
-        Column(header="Box Office", align="right"),
+        Column(header="Box Office", justify="right"),
         title="Star Wars Movies"
     )
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
