### PR TITLE
Update Ubuntu URL in downloader example

### DIFF
--- a/examples/downloader.py
+++ b/examples/downloader.py
@@ -57,7 +57,7 @@ def download(urls: Iterable[str], dest_dir: str):
 
 
 if __name__ == "__main__":
-    # Try with https://releases.ubuntu.com/20.04/ubuntu-20.04-desktop-amd64.iso
+    # Try with https://releases.ubuntu.com/20.04/ubuntu-20.04.1-desktop-amd64.iso
     if sys.argv[1:]:
         download(sys.argv[1:], "./")
     else:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The *Try with* URL in `examples/downloader.py` hits a *404 Not Found* page. It appears on the https://releases.ubuntu.com/20.04/ page, that Ubuntu version `20.04` is no longer offered as a download. Instead version `20.04.1` is offered. I updated the URL in the script to the new version.
