### PR TITLE
make in the line 33 should be `make` .

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Run tests with the following command:
 make test
 ```
 
-Or if you don't have make, run the following:
+Or if you don't have `make`, run the following:
 
 ```
 pytest --cov-report term-missing --cov=rich tests/ -vv


### PR DESCRIPTION
Just like other Module names make should also be in tick marks like this `make`.
It can be a little confusing for newbies.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [X] Documentation / docstrings
- [ ] Tests
- [X] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

Just like the other module names make also should be inside tick marks like this `make` 