### PR TITLE
Fixed the Progress Display Advanced Usage example

### DIFF
--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -34,7 +34,9 @@ If you require multiple tasks in the display, or wish to configure the columns i
 The Progress class is designed to be used as a *context manager* which will start and stop the progress display automatically.
 
 Here's a simple example::
-
+    
+    import time
+    
     from rich.progress import Progress
 
     with Progress() as progress:


### PR DESCRIPTION
The example for [Progress Display Advanced Usage](https://rich.readthedocs.io/en/stable/progress.html#advanced-usage) throws an error
``` 
Traceback (most recent call last):
  File "main.py", line 13, in <module>
    time.sleep(0.02)
NameError: name 'time' is not defined
```
 ```import time``` needs to be added.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
Fixed the Progress Display Advanced Usage example