### PR TITLE
allow stdin on rich.markdown / rich.syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.8.0]
+
+- Allow passing markdown over STDIN when using `python -m rich.markdown`
+
 ## [9.7.0] - 2021-01-09
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,5 +6,6 @@ The following people have contributed to the development of Rich:
 
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Hedy Li](https://github.com/hedythedev)
+- [Alexander Mancevice](https://github.com/amancevice)
 - [Will McGugan](https://github.com/willmcgugan)
 - [Nathan Page](https://github.com/nathanrpage97)

--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -527,11 +527,17 @@ class Markdown(JupyterMixin):
 if __name__ == "__main__":  # pragma: no cover
 
     import argparse
+    import sys
 
     parser = argparse.ArgumentParser(
         description="Render Markdown to the console with Rich"
     )
-    parser.add_argument("path", metavar="PATH", help="path to markdown file")
+    parser.add_argument(
+        "path",
+        metavar="PATH",
+        nargs="?",
+        help="path to markdown file",
+    )
     parser.add_argument(
         "-c",
         "--force-color",
@@ -587,14 +593,18 @@ if __name__ == "__main__":  # pragma: no cover
 
     from rich.console import Console
 
-    with open(args.path, "rt", encoding="utf-8") as markdown_file:
-        markdown = Markdown(
-            markdown_file.read(),
-            justify="full" if args.justify else "left",
-            code_theme=args.code_theme,
-            hyperlinks=args.hyperlinks,
-            inline_code_lexer=args.inline_code_lexer,
-        )
+    if not args.path or args.path == "-":
+        markdown_body = sys.stdin.read()
+    else:
+        with open(args.path, "rt", encoding="utf-8") as markdown_file:
+            markdown_body = markdown_file.read()
+    markdown = Markdown(
+        markdown_body,
+        justify="full" if args.justify else "left",
+        code_theme=args.code_theme,
+        hyperlinks=args.hyperlinks,
+        inline_code_lexer=args.inline_code_lexer,
+    )
     if args.page:
         import pydoc
         import io

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -521,11 +521,17 @@ class Syntax(JupyterMixin):
 if __name__ == "__main__":  # pragma: no cover
 
     import argparse
+    import sys
 
     parser = argparse.ArgumentParser(
         description="Render syntax to the console with Rich"
     )
-    parser.add_argument("path", metavar="PATH", help="path to file")
+    parser.add_argument(
+        "path",
+        metavar="PATH",
+        nargs="?",
+        help="path to file",
+    )
     parser.add_argument(
         "-c",
         "--force-color",
@@ -583,18 +589,30 @@ if __name__ == "__main__":  # pragma: no cover
         default=None,
         help="Overide background color",
     )
+    parser.add_argument(
+        "-L",
+        "--lexer",
+        default="default",
+        dest="lexer_name",
+        help="Lexer name",
+    )
     args = parser.parse_args()
 
     from rich.console import Console
 
     console = Console(force_terminal=args.force_color, width=args.width)
 
-    syntax = Syntax.from_path(
-        args.path,
+    kwargs = dict(
         line_numbers=args.line_numbers,
         word_wrap=args.word_wrap,
         theme=args.theme,
         background_color=args.background_color,
         indent_guides=args.indent_guides,
     )
+
+    if not args.path or args.path == "-":
+        code = sys.stdin.read()
+        syntax = Syntax(code=code, lexer_name=args.lexer_name, **kwargs)
+    else:
+        syntax = Syntax.from_path(args.path, **kwargs)
     console.print(syntax, soft_wrap=args.soft_wrap)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

If user provides no PATH or uses "-" as PATH, markdown is read from sys.stdin.

Examples:

```bash
python -m rich.markdown < README.md
cat README.md | python -m rich.markdown
```