### PR TITLE
fix spelling in docstring

### DIFF
--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -77,7 +77,7 @@ def inspect(
     * inspect(<OBJECT>, methods=True) to see methods.
     * inspect(<OBJECT>, help=True) to see full (non-abbreviated) help.
     * inspect(<OBJECT>, private=True) to see private attributes (single underscore).
-    * inspect(<OBJECT>, dunder=True) to see attributes begining with double underscore.
+    * inspect(<OBJECT>, dunder=True) to see attributes beginning with double underscore.
     * inspect(<OBJECT>, all=True) to see all attributes.
 
     Args:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fix spelling mistake for the word "beginning".
