### PR TITLE
Use `cls` instead of class name in `Traceback.from_exception()`

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -222,7 +222,7 @@ class Traceback:
         rich_traceback = cls.extract(
             exc_type, exc_value, traceback, show_locals=show_locals
         )
-        return Traceback(
+        return cls(
             rich_traceback,
             width=width,
             extra_lines=extra_lines,


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Nothing too special, just changes `Traceback.from_exception()` to not rely on the specific class name and rather refer to `cls`. I'm guessing this probably wasn't meant to be subclassed, but it doesn't hurt to change this.

Haven't added any tests, but I could add a test looking somewhat like this if you think it makes sense to do so:
```py
class SubclassTraceback(Traceback):
    pass

try:
    1 / 0
except Exception:
    assert isinstance(SubclassTraceback.from_exception(*sys.exc_info())
```
