### PR TITLE
fix text indentation in docstring

### DIFF
--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -16,8 +16,8 @@ class InvalidResponse(PromptError):
     """Exception to indicate a response was invalid. Raise this within process_response() to indicate an error
     and provide an error message.
 
-        Args:
-            message (Union[str, Text]): Error message.
+    Args:
+        message (Union[str, Text]): Error message.
     """
 
     def __init__(self, message: TextType) -> None:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The "Args:" section of the docstring was slightly off when compared to other docstrings. Corrected the indentation to make
it consistent with other docstrings.
