### PR TITLE
Use `>` as line pointer when `legacy_windows` option is enabled

### DIFF
--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -480,7 +480,7 @@ class Syntax(JupyterMixin):
         padding = _Segment(" " * numbers_column_width + " ", background_style)
         new_line = _Segment("\n")
 
-        line_pointer = "❱ "
+        line_pointer = "> " if options.legacy_windows else "❱ "
 
         for line_no, line in enumerate(lines, self.start_line + line_offset):
             if self.word_wrap:


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #910 
Let me know if there's a need for adding a test case for this.
