### PR TITLE
Stop `rich.live` from importing same module under a different name

### DIFF
--- a/rich/live.py
+++ b/rich/live.py
@@ -4,7 +4,7 @@ from typing import IO, Any, List, Optional
 
 from typing_extensions import Literal
 
-from .__init__ import get_console
+from . import get_console
 from ._loop import loop_last
 from .console import (
     Console,


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Rich instead of importing from the top-level package using the module name alone, uses module name with `__init__` which makes it get imported twice (under names: `rich` and `rich.__init__`).

Minimal reproduction:
```py
import sys

import rich.live

print(sys.modules["rich"])
print(sys.modules["rich.__init__"])
```
![image](https://user-images.githubusercontent.com/6032823/104433598-91821000-558a-11eb-913d-d42d955f6bdc.png)

I found out about it because [mypy is complaining about it](https://github.com/python/mypy/issues/8944) just because I use rich in my project. However, even if you skip that, this could still possibly lead to some strange issues when depending on the fact that modules in Python are singletons.