### PR TITLE
Do not join refresh thread for Live under lock

### DIFF
--- a/rich/live.py
+++ b/rich/live.py
@@ -157,7 +157,11 @@ class Live(JupyterMixin, RenderHook):
             try:
                 if self.auto_refresh and self._refresh_thread is not None:
                     self._refresh_thread.stop()
-                    self._refresh_thread.join()
+                    self._lock.release()
+                    try:
+                        self._refresh_thread.join()
+                    finally:
+                        self._lock.acquire()
                     self._refresh_thread = None
                 # allow it to fully render on the last even if overflow
                 self.vertical_overflow = "visible"


### PR DESCRIPTION
In the `Live.stop()` method, release `self._lock` before joining the refresh thread. Re-acquire the lock when `Thread.join` returns or raises an exception.

This fixes the following deadlock:

1. `Live.stop`: The main thread acquires the lock.
2. `_RefreshThread.run`: The refresh thread waits for the lock.
3. `Live.stop`: The main thread stops and joins the refresh thread.

Deadlock occurs because the main thread waits for the refresh thread to exit, while the refresh thread waits for the main thread to release the lock.

Fixes #927 
