### PR TITLE
fix: traceback+chdir / slow traceback if FileNotFound / leading lines in source code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unpublished] 
+
+### Fixed
+
+- traceback now correctly retrieve source for the `__main__` script when current working dir has change
+- tracebacks no longer slow down when source files can not be found.
+
 ## [9.8.2] - 2021-01-15
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@ The following people have contributed to the development of Rich:
 
 <!-- Add your name below, sort alphabetically by surname. Link to Github profile / your home page. -->
 
+- [Florian Finkernagel](https://github.com/TyberiusPrime)
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Hedy Li](https://github.com/hedythedev)
 - [Alexander Mancevice](https://github.com/amancevice)


### PR DESCRIPTION
## Type of changes

- [x] Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
Three bugs: 
a) traceback source file finding will not work for the current script if chdir is used, hidding the source of exceptions.
b) traces into 'pxi' files that don't exist slow down traceback formating with pandas quite a bit. 
c) if a source file starts with newlines, the traceback shows the wrong code.

In my tests with pandas, b) pushes a 0.4 second traceback (without rich) to about 4 seconds.
And I need to format the traceback twice, once for a file, once for printing...

This PR fixes all three.
I would have loved to just use inspect.getabsfile() - but it does not work in case of a)
Note that a) is a work around - if the current working dir changes during imports,
this will fail. But who does that.

It should disappear with python 3.9 where I believe get_sourcefile will be absolute 
(thus not entering the '== sys.argv[0]) case).

As for b, the slow down is alleviated, so that it runs in 0.65 seconds now.

I've added tests for a) and c) -  test_cwd_change isn't pretty, but it does work.

I've not added tests for the slow down - not sure if you have benchmarking tests established,
and you probably don't want to have pandas as a testing dependency.

Here's a script to reproduce both:
```python






from rich.traceback import install
import os
import pandas as pd
install()
os.chdir("/tmp")

df = pd.DataFrame({'column0': [1]})
df['sha']
```

which prior to this PR leads to 
```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /tmp/show_pandas_being_slow.py:8 in <module>                                                     │
│ FileNotFoundError: [Errno 2] No such file or directory: '/tmp/show_pandas_being_slow.py'         │
``

and (without the os.chdir)
```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/finkernagel/upstream/rich_dev/shu.py:13 in <module>                                        │
│                                                                                                  │
│                                                                                                  │
│ /home/finkernagel/upstream/rich_dev/shu.py:10 in explode                                         │
│                                                                                                  │
│    7                                                                                             │
│    8 #os.chdir('/tmp')                                                                           │
│    9 explode() # sentinel2                                                                       │
```
(note the 'empty' trace in 13, and the missing >).


