### PR TITLE
Fix initial table headers missing style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix double line tree guides on Windows
+- Fix initial table headers missing style https://github.com/willmcgugan/rich/issues/953
 
 ### Added
 

--- a/rich/table.py
+++ b/rich/table.py
@@ -170,9 +170,17 @@ class Table(JupyterMixin):
         append_column = self.columns.append
         for index, header in enumerate(headers):
             if isinstance(header, str):
-                append_column(Column(_index=index, header=header))
+                append_column(
+                    Column(
+                        _index=index,
+                        header=header,
+                        header_style=Style.pick_first(header_style, "table.header"),
+                    )
+                )
             else:
                 header._index = index
+                if header.header_style == "table.header":
+                    header.header_style = Style.pick_first(header_style, "table.header")
                 append_column(header)
 
         self.title = title

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,14 +1,13 @@
 # encoding=utf-8
 
 import io
-from rich import color
 
 import pytest
 
-from rich import errors
+from rich import color, errors
 from rich.console import Console
 from rich.measure import Measurement
-from rich.table import Table, Column
+from rich.table import Column, Table
 from rich.text import Text
 
 
@@ -103,6 +102,40 @@ def test_init_append_column():
     assert Table(*header_names).columns == test_columns
     # Test directly passing a Table Column objects
     assert Table(*test_columns).columns == test_columns
+
+
+def test_init_append_column_style():
+    header_names = ["header1", "header2", "header3"]
+
+    test_columns_with_style = [
+        Column(_index=index, header=header, header_style="bold red")
+        for index, header in enumerate(header_names)
+    ]
+
+    # Test appending of strings for header names with style
+    assert (
+        Table(*header_names, header_style="bold red").columns == test_columns_with_style
+    )
+
+    test_columns_without_style = [
+        Column(_index=index, header=header) for index, header in enumerate(header_names)
+    ]
+
+    # Test appending of strings for header names without style
+    assert (
+        Table(*test_columns_without_style, header_style="bold red").columns
+        == test_columns_with_style
+    )
+
+    test_columns_with_diff_style = [
+        Column(_index=index, header=header, header_style="bold green")
+        for index, header in enumerate(header_names)
+    ]
+    # Test directly passing a Table Column objects with different style
+    assert (
+        Table(*test_columns_with_diff_style, header_style="bold red").columns
+        == test_columns_with_diff_style
+    )
 
 
 def test_rich_measure():


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [X] Documentation / docstrings
- [X] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description
Fix issue: https://github.com/willmcgugan/rich/issues/953

When create table with initial "headers" and "header style":

- If header is a string or a non-style Column object, instead by "header style" above.

```python
table = Table("DATE", Column(_index=1, header="NAME"), header_style="bold red")
table.add_column("AGE")
```

![image](https://user-images.githubusercontent.com/30592265/105565365-630ded00-5d61-11eb-8379-e3bf3af016cc.png)

- If header is a style Column object, keep its own style.

```python
table = Table(
        "DATE",
        Column(_index=0, header="NAME", header_style="bold green"),
        header_style="bold red",
    )
table.add_column("AGE")
```

![image](https://user-images.githubusercontent.com/30592265/105565390-88026000-5d61-11eb-83af-b1e9f35d790c.png)

