### PR TITLE
fix incorrect texts in docstring

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -1024,8 +1024,8 @@ class Console:
 
         Args:
             objects (Iterable[Any]): Anything that Rich can render.
-            sep (str): String to write between print data. Defaults to " ".
-            end (str): String to write at end of print data. Defaults to "\\n".
+            sep (str): String to write between print data.
+            end (str): String to write at end of print data.
             justify (str, optional): One of "left", "right", "center", or "full". Defaults to ``None``.
             emoji (Optional[bool], optional): Enable emoji code, or ``None`` to use console default.
             markup (Optional[bool], optional): Enable markup, or ``None`` to use console default.

--- a/rich/console.py
+++ b/rich/console.py
@@ -1020,19 +1020,19 @@ class Console:
         markup: bool = None,
         highlight: bool = None,
     ) -> List[ConsoleRenderable]:
-        """Combined a number of renderables and text in to one renderable.
+        """Combine a number of renderables and text into one renderable.
 
         Args:
             objects (Iterable[Any]): Anything that Rich can render.
-            sep (str, optional): String to write between print data. Defaults to " ".
-            end (str, optional): String to write at end of print data. Defaults to "\\n".
+            sep (str): String to write between print data. Defaults to " ".
+            end (str): String to write at end of print data. Defaults to "\\n".
             justify (str, optional): One of "left", "right", "center", or "full". Defaults to ``None``.
             emoji (Optional[bool], optional): Enable emoji code, or ``None`` to use console default.
             markup (Optional[bool], optional): Enable markup, or ``None`` to use console default.
             highlight (Optional[bool], optional): Enable automatic highlighting, or ``None`` to use console default.
 
         Returns:
-            List[ConsoleRenderable]: A list oxf things to render.
+            List[ConsoleRenderable]: A list of things to render.
         """
         renderables: List[ConsoleRenderable] = []
         _append = renderables.append


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Corrected a few things in the docstring of the method `_collect_renderables` in `rich.console.Console` class. Major changes:
1. the arguments `sep` and `end` were documented as `optional` while they are not optional -- corrected.
2. corrected the grammatical mistakes and typos.
