### PR TITLE
fix printing sequences with overflow=wrap

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -1052,6 +1052,7 @@ class Console:
         emoji: bool = None,
         markup: bool = None,
         highlight: bool = None,
+        overflow: OverflowMethod = "crop",
     ) -> List[ConsoleRenderable]:
         """Combine a number of renderables and text into one renderable.
 
@@ -1111,7 +1112,7 @@ class Console:
                 append(renderable)
             elif isinstance(renderable, (abc.Mapping, abc.Sequence, abc.Set)):
                 check_text()
-                append(Pretty(renderable, highlighter=_highlighter))
+                append(Pretty(renderable, highlighter=_highlighter, overflow=overflow))
             else:
                 append_text(_highlighter(str(renderable)))
 
@@ -1242,6 +1243,7 @@ class Console:
                 emoji=emoji,
                 markup=markup,
                 highlight=highlight,
+                overflow=overflow if overflow is not None else "crop",
             )
             for hook in self._render_hooks:
                 renderables = hook.process_renderables(renderables)


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Issue described in #995. The default behavior will still crop, so `rich.print()` will fail. But `console.print()` will work:
```python

from rich.console import Console
console = Console()
console.print(["a" * 300], crop=False)
```