### PR TITLE
Add missing closing string quote to Layout example in doc

### DIFF
--- a/docs/source/layout.rst
+++ b/docs/source/layout.rst
@@ -79,7 +79,7 @@ The first position argument to ``Layout`` can be any Rich renderable, which will
 
     layout["right"].split(
         Layout(Panel("Hello")),
-        Layout(Panel("World!))
+        Layout(Panel("World!"))
     )
 
 You can also call :meth:`~rich.layout.Layout.update` to set or replace the current renderable::


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added a missing closing quote to an example in the `Layout` docs.

---

Thanks for the project, looking forward to trying out the new `Layout`!
