### PR TITLE
Test prompt confirm with choices

### DIFF
--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -329,8 +329,30 @@ class Confirm(PromptBase[bool]):
     """
 
     response_type = bool
-    validate_error_message = "[prompt.invalid]Please enter Y or N"
     choices = ["y", "n"]
+
+    def __init__(
+        self,
+        prompt: TextType = "",
+        *,
+        console: Console = None,
+        password: bool = False,
+        choices: List[str] = None,
+        show_default: bool = True,
+        show_choices: bool = True,
+    ):
+        super().__init__(
+            prompt=prompt,
+            console=console,
+            password=password,
+            choices=choices,
+            show_default=show_default,
+            show_choices=show_choices,
+        )
+
+        self.validate_error_message = "[prompt.invalid]Please enter " + " or ".join(
+            [c.upper() for c in self.choices]
+        )
 
     def render_default(self, default: DefaultType) -> Text:
         """Render the default as (y) or (n) rather than True/False."""

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -93,3 +93,20 @@ def test_prompt_confirm_default():
     output = console.file.getvalue()
     print(repr(output))
     assert output == expected
+
+
+def test_prompt_confirm_default_with_choices():
+    INPUT = "foo\nn\nNO"
+    console = Console(file=io.StringIO())
+    answer = Confirm.ask(
+        "continue",
+        console=console,
+        stream=io.StringIO(INPUT),
+        default=True,
+        choices=["yes", "no"],
+    )
+    assert answer is False
+    expected = "continue [yes/no] (yes): Please enter YES or NO\ncontinue [yes/no] (yes): Please enter YES or NO\ncontinue [yes/no] (yes): "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review. (<3)

## Description

Currently `rich.prompt.Confirm.ask` prints `Please enter Y or N` even when choices are setup, resulting is this absurd behaviour
<img width="422" alt="Screenshot 2021-02-26 at 09 54 56" src="https://user-images.githubusercontent.com/14075922/109278325-b10e8880-7818-11eb-8891-bfd0838f745b.png">

My change adresses this, _but_ writing this I realised it doesn't solve the deeper issue : this method accepts a `choices` kwargs, which only makes sense in case where the value passes is a sensible mapping for `[True, False]`.

It could check that `len(choices)==2` for instance, but there's no reliable way to check that the order makes sense.
Because it's a just a convenience wrapper, I think the best option would instead be to remove `choices` from 
`rich.prompt.Confirm.__init__` signature. WDYT ?