### PR TITLE
Fix google colab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.12.5] - 2021-03-02
+
+### Fixed
+
+- Fixed issue where juptyer was not being detected in Google Colab
+
 ## [9.12.4] - 2021-03-01
 
 ### Fixed

--- a/rich/console.py
+++ b/rich/console.py
@@ -409,11 +409,12 @@ def _is_jupyter() -> bool:  # pragma: no cover
     except NameError:
         return False
     shell = get_ipython().__class__.__name__  # type: ignore
+    full_class = str(get_ipython().__class__) # type: ignore 
     if shell == "ZMQInteractiveShell":
         return True  # Jupyter notebook or qtconsole
     elif shell == "TerminalInteractiveShell":
         return False  # Terminal running IPython
-    elif "google.colab" in str(get_ipython()):  # IPython in Google Colab
+    elif "google.colab" in full_class:  # IPython in Google Colab
         return True
     else:
         return False  # Other type (?)

--- a/rich/console.py
+++ b/rich/console.py
@@ -409,7 +409,7 @@ def _is_jupyter() -> bool:  # pragma: no cover
     except NameError:
         return False
     shell = get_ipython().__class__.__name__  # type: ignore
-    full_class = str(get_ipython().__class__) # type: ignore 
+    full_class = str(get_ipython().__class__)  # type: ignore
     if shell == "ZMQInteractiveShell":
         return True  # Jupyter notebook or qtconsole
     elif shell == "TerminalInteractiveShell":

--- a/rich/console.py
+++ b/rich/console.py
@@ -413,7 +413,7 @@ def _is_jupyter() -> bool:  # pragma: no cover
         return True  # Jupyter notebook or qtconsole
     elif shell == "TerminalInteractiveShell":
         return False  # Terminal running IPython
-    elif 'google.colab' in str(get_ipython()): # IPython in Google Colab
+    elif "google.colab" in str(get_ipython()):  # IPython in Google Colab
         return True
     else:
         return False  # Other type (?)

--- a/rich/console.py
+++ b/rich/console.py
@@ -413,6 +413,8 @@ def _is_jupyter() -> bool:  # pragma: no cover
         return True  # Jupyter notebook or qtconsole
     elif shell == "TerminalInteractiveShell":
         return False  # Terminal running IPython
+    elif 'google.colab' in str(get_ipython()): # IPython in Google Colab
+        return True
     else:
         return False  # Other type (?)
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

`rich.console._is_juptyer` was returning false when running in Google Colab's jupyter notebook. It seems to have its own IPython Shell class or something. If you force juptyer things seem to work. I thought this should be the default when doing `from rich.juptyer import print`. Its a simple change that detects if we are running in colab specifically. Not sure the best way to write a test for this so I didn't add any new tests. Here is a working example:

[rich_test.ipynb - Colab Example](https://colab.research.google.com/drive/1Ks3mBg_1wFLYeXQSFBfbNuoj9v8NHDKj?usp=sharing)

Anyway, not sure if you want this to be the default behavior but if you do this should handle it. Also, thanks for the great library.

Dave
