### PR TITLE
Support extras in logging handler

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,9 +4,11 @@ The following people have contributed to the development of Rich:
 
 <!-- Add your name below, sort alphabetically by surname. Link to Github profile / your home page. -->
 
+- [Travis Cook](https://github.com/traviscook21)
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Finn Hughes](https://github.com/finnhughes)
 - [Hedy Li](https://github.com/hedythedev)
 - [Alexander Mancevice](https://github.com/amancevice)
 - [Will McGugan](https://github.com/willmcgugan)
 - [Nathan Page](https://github.com/nathanrpage97)
+

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -8,6 +8,7 @@ from . import get_console
 from ._log_render import LogRender, FormatTimeCallable
 from .console import Console, ConsoleRenderable
 from .highlighter import Highlighter, ReprHighlighter
+from .pretty import Pretty
 from .text import Text
 from .traceback import Traceback
 
@@ -37,6 +38,7 @@ RESERVED_ATTRS = (
     "thread",
     "threadName",
 )
+
 
 class RichHandler(Handler):
     """A logging handler that renders output with Rich. The time / level / message and file are displayed in columns.
@@ -237,11 +239,14 @@ class RichHandler(Handler):
         )
         return log_renderable
 
-    def _render_extras(self, record: logging.LogRecord) -> Optional["ConsoleRendereable"]:
-        from rich.pretty import Pretty
+    def _render_extras(
+        self, record: logging.LogRecord
+    ) -> Optional["ConsoleRenderable"]:
         obj = {}
         for k, v in record.__dict__.items():
-            if k not in RESERVED_ATTRS and not (hasattr(k, "startswith") and k.startswith("_")):
+            if k not in RESERVED_ATTRS and not (
+                hasattr(k, "startswith") and k.startswith("_")
+            ):
                 obj[k] = v
         if obj:
             return Pretty(obj)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -106,7 +106,6 @@ def test_handler_with_extras():
     log.addHandler(handler_with_extras)
     log.warning("Message", extra={"extra_key": "extra_value"})
 
-
     render = handler_with_extras.console.file.getvalue()
     print(render)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -89,6 +89,31 @@ def test_exception_with_extra_lines():
     assert "division by zero" in render
 
 
+def test_handler_with_extras():
+    console = Console(
+        file=io.StringIO(),
+        force_terminal=True,
+        width=140,
+        color_system=None,
+        _environ={},
+    )
+    handler_with_extras = RichHandler(
+        console=console,
+        enable_link_path=False,
+        markup=True,
+        include_extras=True,
+    )
+    log.addHandler(handler_with_extras)
+    log.warning("Message", extra={"extra_key": "extra_value"})
+
+
+    render = handler_with_extras.console.file.getvalue()
+    print(render)
+
+    assert "extra_key" in render
+    assert "extra_value" in render
+
+
 if __name__ == "__main__":
     render = make_log()
     print(render)


### PR DESCRIPTION
When a user passes extras into a log statement, those extras
don't show up in the rich logging handler.

```
log.info("Message", extra={"foo": "bar"})
```

Now, there's a conditional option `include_extra` which
will tell the `RichHandler` to include the extras on the
next lines of the message as a `Pretty` object

## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
