### PR TITLE
add option to not omit identical time values in log renderer

### DIFF
--- a/rich/_log_render.py
+++ b/rich/_log_render.py
@@ -18,12 +18,14 @@ class LogRender:
         show_level: bool = False,
         show_path: bool = True,
         time_format: Union[str, FormatTimeCallable] = "[%x %X]",
+        repeat_same_time: bool = False,
         level_width: Optional[int] = 8,
     ) -> None:
         self.show_time = show_time
         self.show_level = show_level
         self.show_path = show_path
         self.time_format = time_format
+        self.repeat_same_time = repeat_same_time
         self.level_width = level_width
         self._last_time: Optional[Text] = None
 
@@ -58,7 +60,7 @@ class LogRender:
                 log_time_display = time_format(log_time)
             else:
                 log_time_display = Text(log_time.strftime(time_format))
-            if log_time_display == self._last_time:
+            if log_time_display == self._last_time and not self.repeat_same_time:
                 row.append(Text(" " * len(log_time_display)))
             else:
                 row.append(log_time_display)

--- a/rich/_log_render.py
+++ b/rich/_log_render.py
@@ -18,14 +18,14 @@ class LogRender:
         show_level: bool = False,
         show_path: bool = True,
         time_format: Union[str, FormatTimeCallable] = "[%x %X]",
-        repeat_same_time: bool = False,
+        omit_repeated_times: bool = True,
         level_width: Optional[int] = 8,
     ) -> None:
         self.show_time = show_time
         self.show_level = show_level
         self.show_path = show_path
         self.time_format = time_format
-        self.repeat_same_time = repeat_same_time
+        self.omit_repeated_times = omit_repeated_times
         self.level_width = level_width
         self._last_time: Optional[Text] = None
 
@@ -60,7 +60,7 @@ class LogRender:
                 log_time_display = time_format(log_time)
             else:
                 log_time_display = Text(log_time.strftime(time_format))
-            if log_time_display == self._last_time and not self.repeat_same_time:
+            if log_time_display == self._last_time and self.omit_repeated_times:
                 row.append(Text(" " * len(log_time_display)))
             else:
                 row.append(log_time_display)

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -25,7 +25,7 @@ class RichHandler(Handler):
         console (:class:`~rich.console.Console`, optional): Optional console instance to write logs.
             Default will use a global console instance writing to stdout.
         show_time (bool, optional): Show a column for the time. Defaults to True.
-        repeat_same_time (bool, optional): Do not omit repetition of the same time. Defaults to False.
+        omit_repeated_times (bool, optional): Omit repetition of the same time. Defaults to True.
         show_level (bool, optional): Show a column for the level. Defaults to True.
         show_path (bool, optional): Show the path to the original log call. Defaults to True.
         enable_link_path (bool, optional): Enable terminal link of path column to file. Defaults to True.
@@ -61,7 +61,7 @@ class RichHandler(Handler):
         console: Console = None,
         *,
         show_time: bool = True,
-        repeat_same_time: bool = False,
+        omit_repeated_times: bool = True,
         show_level: bool = True,
         show_path: bool = True,
         enable_link_path: bool = True,
@@ -85,7 +85,7 @@ class RichHandler(Handler):
             show_level=show_level,
             show_path=show_path,
             time_format=log_time_format,
-            repeat_same_time=repeat_same_time,
+            omit_repeated_times=omit_repeated_times,
             level_width=None,
         )
         self.enable_link_path = enable_link_path

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -25,6 +25,7 @@ class RichHandler(Handler):
         console (:class:`~rich.console.Console`, optional): Optional console instance to write logs.
             Default will use a global console instance writing to stdout.
         show_time (bool, optional): Show a column for the time. Defaults to True.
+        repeat_same_time (bool, optional): Do not omit repetition of the same time. Defaults to False.
         show_level (bool, optional): Show a column for the level. Defaults to True.
         show_path (bool, optional): Show the path to the original log call. Defaults to True.
         enable_link_path (bool, optional): Enable terminal link of path column to file. Defaults to True.
@@ -60,6 +61,7 @@ class RichHandler(Handler):
         console: Console = None,
         *,
         show_time: bool = True,
+        repeat_same_time: bool = False,
         show_level: bool = True,
         show_path: bool = True,
         enable_link_path: bool = True,
@@ -83,6 +85,7 @@ class RichHandler(Handler):
             show_level=show_level,
             show_path=show_path,
             time_format=log_time_format,
+            repeat_same_time=repeat_same_time,
             level_width=None,
         )
         self.enable_link_path = enable_link_path


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I really like the RichHandler for logging, but I find it not so nice that it omits time values if the line above has the same time value. The Main reason is, that I often send snippets of log messages around and then the time is missing because everything happened within a second. My change is a `repeat_same_time=True` switch to RichHandler (and LogRender) to turn off this behavior. 

``` python3
import logging
from rich.logging import RichHandler

logger = logging.getLogger()
logger.addHandler(RichHandler(repeat_same_time=True))

logger.error("A")
logger.error("B")
```

Before (or with `repeat_same_time=False`):
```
[03/13/21 13:35:55] ERROR    A
                    ERROR    B
```

After:
```
[03/13/21 13:36:08] ERROR    A
[03/13/21 13:36:08] ERROR    B