### PR TITLE
fix f-string with missing f

### DIFF
--- a/docs/source/live.rst
+++ b/docs/source/live.rst
@@ -123,7 +123,7 @@ The Live class will create an internal Console object which you can access via `
 
     with Live(table, refresh_per_second=4) as live:  # update 4 times a second to feel fluid
         for row in range(12):
-            live.console.print("Working on row #{row}")
+            live.console.print(f"Working on row #{row}")
             time.sleep(0.4)
             table.add_row(f"{row}", f"description {row}", "[red]ERROR")
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.
                                                                    👆 Love this


## Description

Stumbled into a missing leading f in an `f-string` in one of the docs examples.  Feel free to accept the PR or close and make the fix yourself. 