### PR TITLE
Function Name in Logger by Default

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -200,7 +200,7 @@ class RichHandler(Handler):
             time_format=time_format,
             level=level,
             path=path,
-            line_no=record.lineno,
+            line_no=f'{record.funcName}:{record.lineno}',
             link_path=record.pathname if self.enable_link_path else None,
         )
         return log_renderable


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Really wanted to have function name as part of file name and line number