### PR TITLE
Allow Console.print(markup=) to override Console defaults

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -1402,6 +1402,9 @@ class Console:
             crop = False
 
         with self:
+            if markup is not None:
+                self._markup = markup
+
             renderables = self._collect_renderables(
                 objects,
                 sep,

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -152,6 +152,19 @@ def test_no_columns():
     assert output == "\n"
 
 
+def test_print_markup_false():
+    no_markup = "Do not [/] attempt to markup this text"
+    console = Console()
+    table = Table()
+    table.add_column("test_print_markup_false")
+    table.add_row(no_markup)
+    console.begin_capture()
+    console.print(table, markup=False)
+    output = console.end_capture()
+    print(repr(output))
+    assert no_markup in output
+
+
 if __name__ == "__main__":
     render = render_tables()
     print(render)


### PR DESCRIPTION
## Type of changes

- [✅] Bug fix

## Checklist

- [✅] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [✅] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [✅] I've added tests for new code.
- [✅] I accept that @willmcgugan may be pedantic in the code review.

## Description

When `print(markup=)` is passed in, set the Console default value in the context manager so that renderables can see it.

Fixes: issue #1117