### PR TITLE
Updates example/layout.py to use Splitter class

### DIFF
--- a/examples/layout.py
+++ b/examples/layout.py
@@ -23,9 +23,7 @@ layout.split(
     Layout(size=10, name="footer"),
 )
 
-layout["main"].split(
-    Layout(name="side"), Layout(name="body", ratio=2), direction="horizontal"
-)
+layout["main"].split_row(Layout(name="side"), Layout(name="body", ratio=2))
 
 layout["side"].split(Layout(), Layout())
 

--- a/rich/layout.py
+++ b/rich/layout.py
@@ -40,7 +40,6 @@ class LayoutRender(NamedTuple):
 
 RegionMap = Dict["Layout", Region]
 RenderMap = Dict["Layout", LayoutRender]
-Direction = Literal["horizontal", "vertical"]
 
 
 class LayoutError(Exception):


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Resolves a TypeError when running `examples/layout.py` using `rich=10.0.0`.

### What's Changed

Whilst upgrading from `9.13.0` to `10.0.0` within my application I encountered a breaking changed related to `direction` being removed and replaced with the new [Splitter](https://rich.readthedocs.io/en/latest/layout.html?highlight=split_column#creating-layouts) class as outlined in the [changelog](https://github.com/willmcgugan/rich/releases). 

Upon inspecting the source and running the example I noticed it had not been updated to reflect the latest changes.

This PR removes the unused `Direction` literal and updates `example/layout.py` to use `split_row` instead of `direction="horizontal"` to help others quickly identify the necessary change.  

### Steps to reproduce

Run `examples/layout.py` using `rich==10.0.0` to produce the following TypeError:

```bash
Traceback (most recent call last):
  File "/home/host/workspace/apoclyps/rich/examples/layout.py", line 26, in <module>
    layout["main"].split(
TypeError: split() got an unexpected keyword argument 'direction'
```

