### PR TITLE
introduction.rst: Correct some Windows details

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -10,7 +10,7 @@ Requirements
 
 Rich works with OSX, Linux and Windows.
 
-On Windows both the (ancient) cmd.exe terminal is supported and the new `Windows Terminal <https://github.com/microsoft/terminal/releases>`_. The later has much improved support for color and style.
+On Windows both the classic console and the new `Windows Terminal <https://github.com/microsoft/terminal>`_ are supported. When they're available (and if Windows Terminal works, they are), rich can use `virtual terminal sequences <https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences>`_ for improved support for color and style. Unfortunately, the classic console doesn't (yet?) support emoji (`issue <https://github.com/Microsoft/Terminal/issues/190>`_).
 
 Rich requires Python 3.6.1 and above. Note that Python 3.6.0 is *not* supported due to lack of support for methods on NamedTuples.
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code. *I didn't write any.*
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate. *Is this needed for docs tweaks?*
- [ ] I've added tests for new code. *I didn't write any.*
- [x] I accept that @willmcgugan may be pedantic in the code review. *Yes please.*

## Description

Rewrite one paragraph of introduction.rst to accommodate these facts:
1. The classic console UI has little to do with cmd.exe.
2. You don't need Windows Terminal to get virtual terminal sequences;
   they work just as well with the classic UI (as long as nobody turned on "legacy" mode).

[Caveat: Windows Terminal updates ship more often than conhost.exe updates.]