### PR TITLE
Stop showing colon after exception type when there is no message

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -444,11 +444,13 @@ class Traceback:
                     (f"{stack.exc_type}: ", "traceback.exc_type"),
                     highlighter(stack.syntax_error.msg),
                 )
-            else:
+            elif stack.exc_value:
                 yield Text.assemble(
                     (f"{stack.exc_type}: ", "traceback.exc_type"),
                     highlighter(stack.exc_value),
                 )
+            else:
+                yield Text.assemble((f"{stack.exc_type}", "traceback.exc_type"))
 
             if not last:
                 if stack.is_cause:

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -81,6 +81,17 @@ def test_print_exception():
     assert "ZeroDivisionError" in exception_text
 
 
+def test_print_exception_no_msg():
+    console = Console(width=100, file=io.StringIO())
+    try:
+        raise RuntimeError
+    except Exception:
+        console.print_exception()
+    exception_text = console.file.getvalue()
+    assert "RuntimeError" in exception_text
+    assert "RuntimeError:" not in exception_text
+
+
 def test_print_exception_locals():
     console = Console(width=100, file=io.StringIO())
     try:


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This updates the shown traceback so that it does not include a colon if there is no exception message. This is in line with Python's default traceback handler.
Here's a screenshot that will probably explain it even better:
![image](https://user-images.githubusercontent.com/6032823/114269847-6718e500-9a09-11eb-9a67-93e5b672892d.png)
