### PR TITLE
Fixes a split_row() bug in examples/fullscreen.py

### DIFF
--- a/examples/fullscreen.py
+++ b/examples/fullscreen.py
@@ -27,9 +27,10 @@ def make_layout() -> Layout:
         Layout(name="main", ratio=1),
         Layout(name="footer", size=7),
     )
-    layout["main"].split_row(
+    layout["main"].split(
         Layout(name="side"),
         Layout(name="body", ratio=2, minimum_size=60),
+        direction='horizontal'
     )
     layout["side"].split(Layout(name="box1"), Layout(name="box2"))
     return layout

--- a/examples/fullscreen.py
+++ b/examples/fullscreen.py
@@ -30,7 +30,7 @@ def make_layout() -> Layout:
     layout["main"].split(
         Layout(name="side"),
         Layout(name="body", ratio=2, minimum_size=60),
-        direction='horizontal'
+        direction="horizontal",
     )
     layout["side"].split(Layout(name="box1"), Layout(name="box2"))
     return layout


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes the `fullscreen.py` example to use `Layout.split(direction='horizontal')` instead of `Layout.split_row()`. Verified to work locally via `python3 fullscreen.py`.