### PR TITLE
Use typing-extensions on py<3.8 

### DIFF
--- a/examples/top_lite_simulator.py
+++ b/examples/top_lite_simulator.py
@@ -9,7 +9,11 @@ from rich import box
 from rich.console import Console
 from rich.live import Live
 from rich.table import Table
-from typing_extensions import Literal
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ include = ["rich/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-typing-extensions = "^3.7.4"
+typing-extensions = {version = "^3.7.4", python = "<3.8"}
 dataclasses = {version=">=0.7,<0.9", python = "~3.6"} 
 pygments = "^2.6.0"
 commonmark = "^0.9.0"

--- a/rich/_ratio.py
+++ b/rich/_ratio.py
@@ -1,7 +1,11 @@
 from fractions import Fraction
 from math import ceil, floor, modf
 from typing import cast, List, Optional, Sequence
-from typing_extensions import Protocol
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol
 
 
 class Edge(Protocol):

--- a/rich/align.py
+++ b/rich/align.py
@@ -1,7 +1,11 @@
 from itertools import chain
 from typing import Iterable, Optional, TYPE_CHECKING
 
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from .constrain import Constrain
 from .jupyter import JupyterMixin
 from .measure import Measurement

--- a/rich/box.py
+++ b/rich/box.py
@@ -1,6 +1,9 @@
 from typing import TYPE_CHECKING, Iterable, List
 
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from ._loop import loop_last
 

--- a/rich/console.py
+++ b/rich/console.py
@@ -28,7 +28,10 @@ from typing import (
     cast,
 )
 
-from typing_extensions import Literal, Protocol, runtime_checkable
+try:
+    from typing import Literal, Protocol, runtime_checkable
+except ImportError:
+    from typing_extensions import Literal, Protocol, runtime_checkable
 
 from . import errors, themes
 from ._emoji_replace import _emoji_replace

--- a/rich/live_render.py
+++ b/rich/live_render.py
@@ -1,7 +1,10 @@
 from threading import RLock
 from typing import Optional, Tuple
 
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from ._loop import loop_last
 from .console import Console, ConsoleOptions, RenderableType, RenderResult

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,8 @@ isolated_build = True
 
 [testenv]
 description = Run unit-testing
-# develop temporary disabled as project packaging does not work with it yet:
-# https://github.com/willmcgugan/rich/issues/345
-usedevelop = False
 deps =
-    -r requirements-dev.txt
+    poetry
 # do not put * in passenv as it may break builds due to reduced isolation
 passenv =
     CI
@@ -25,8 +22,7 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1
 commands =
-    # failsafe as older pip may install incompatible dependencies
-    pip check
+    poetry install
     pytest --cov-report term-missing --cov=rich tests/ {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Use `typing-extensions` package only in Python < 3.8. Python 3.8+ has everything in the built-in `typing` module.

Note: I didn't update `poetry.lock` as this causes a major change to everything. I don't really know how poetry-based workflow works.