### PR TITLE
add Console.measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [10.1.1] - Unreleased
+## [10.2.0] - Unreleased
 
 ### Added
 
-- Added syntax for call, i.e. "Foo(bar)" will highlight Foo.pyth
+- Added syntax for call, i.e. "Foo(bar)"
+- Added Console.measure as a convenient alias for Measurement.get
 
 ## [10.1.0] - 2020-04-03
 

--- a/examples/table_movie.py
+++ b/examples/table_movie.py
@@ -111,7 +111,7 @@ with Live(table_centered, console=console, screen=False, refresh_per_second=20):
     with beat(10):
         table.show_footer = True
 
-    table_width = Measurement.get(console, console.options, table).maximum
+    table_width = console.measure(table).maximum
 
     with beat(10):
         table.columns[2].justify = "right"
@@ -175,7 +175,7 @@ with Live(table_centered, console=console, screen=False, refresh_per_second=20):
     with beat(10):
         table.pad_edge = False
 
-    original_width = Measurement.get(console, console.options, table).maximum
+    original_width = console.measure(table).maximum
 
     for width in range(original_width, console.width, 2):
         with beat(1):

--- a/rich/align.py
+++ b/rich/align.py
@@ -137,7 +137,7 @@ class Align(JupyterMixin):
         self, console: "Console", options: "ConsoleOptions"
     ) -> "RenderResult":
         align = self.align
-        width = Measurement.get(console, options, self.renderable).maximum
+        width = console.measure(self.renderable, options=options).maximum
         rendered = console.render(
             Constrain(
                 self.renderable, width if self.width is None else min(width, self.width)

--- a/rich/console.py
+++ b/rich/console.py
@@ -1092,6 +1092,23 @@ class Console:
         """
         return ScreenContext(self, hide_cursor=hide_cursor, style=style or "")
 
+    def measure(
+        self, renderable: RenderableType, *, options: Optional[ConsoleOptions] = None
+    ) -> Measurement:
+        """Measure a renderable. Returns a :class:`~rich.measure.Measurement` object which contains
+        information regarding the number of characters required to print the renderable.
+
+        Args:
+            renderable (RenderableType): Any renderable or string.
+            options (Optional[ConsoleOptions], optional): Options to use when measuring, or None
+                to use default options. Defaults to None.
+
+        Returns:
+            Measurement: A measurement of the renderable.
+        """
+        measurement = Measurement.get(self, options or self.options, renderable)
+        return measurement
+
     def render(
         self, renderable: RenderableType, options: Optional[ConsoleOptions] = None
     ) -> Iterable[Segment]:

--- a/rich/panel.py
+++ b/rich/panel.py
@@ -133,8 +133,8 @@ class Panel(JupyterMixin):
         child_width = (
             width - 2
             if self.expand
-            else Measurement.get(
-                console, options.update_width(width - 2), renderable
+            else console.measure(
+                renderable, options=options.update_width(width - 2)
             ).maximum
         )
         child_height = self.height or options.height or None


### PR DESCRIPTION
Adds a Console.measure convenience methods.

This is convenient because you don't need an extra import. It can also be shorter if you are using default options.