### PR TITLE
fix color output in spyder console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed initial blank lines removed from Syntax https://github.com/willmcgugan/rich/issues/1214
 - Added Console.measure as a convenient alias for Measurement.get
 
+### Fixed
+
+- Colors are now shown in the Spyder console
+
 ## [10.1.0] - 2020-04-03
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@ The following people have contributed to the development of Rich:
 
 <!-- Add your name below, sort alphabetically by surname. Link to Github profile / your home page. -->
 
+- [Pieter Eendebak](https://github.com/eendebakpt)
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Finn Hughes](https://github.com/finnhughes)
 - [Josh Karpel](https://github.com/JoshKarpel)

--- a/rich/console.py
+++ b/rich/console.py
@@ -523,9 +523,11 @@ def detect_legacy_windows() -> bool:
     """Detect legacy Windows."""
     return WINDOWS and not get_windows_console_features().vt
 
+
 def detect_spyder_environment() -> bool:
-    """  Return True if running in the Spyder environment """
-    return 'SPY_PYTHONPATH' in os.environ
+    """Return True if running in the Spyder environment"""
+    return "SPY_PYTHONPATH" in os.environ
+
 
 if detect_legacy_windows():  # pragma: no cover
     from colorama import init

--- a/rich/console.py
+++ b/rich/console.py
@@ -523,11 +523,17 @@ def detect_legacy_windows() -> bool:
     """Detect legacy Windows."""
     return WINDOWS and not get_windows_console_features().vt
 
+def detect_spyder_environment() -> bool:
+    """  Return True if running in the Spyder environment """
+    return 'SPY_PYTHONPATH' in os.environ
 
 if detect_legacy_windows():  # pragma: no cover
     from colorama import init
 
-    init()
+    if detect_spyder_environment():
+        init(strip=False)
+    else:
+        init()
 
 
 class Console:

--- a/rich/console.py
+++ b/rich/console.py
@@ -864,6 +864,9 @@ class Console:
         """
         if self._force_terminal is not None:
             return self._force_terminal
+        if detect_spyder_environment():
+            # not sure why in spyder the normal checks returns False
+            return True
         isatty = getattr(self.file, "isatty", None)
         return False if isatty is None else isatty()
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Enable colored output with [Spyder](https://github.com/spyder-ide/spyder)

This PR addresses two issues: 

* `colorama` needs to be initialized with the option `strip=False` in Spyder
* In the spyder environment the method `is_terminal` returns False, where it should return True. This is solved by creating a new method `detect_spyder_environment`

Related: #1149, https://github.com/spyder-ide/spyder/issues/15496, https://github.com/spyder-ide/spyder/issues/1917

A screenshot of Spyder with the PR:

![image](https://user-images.githubusercontent.com/883786/117451032-44171d80-af42-11eb-8fa1-6f9bf301a4be.png)