### PR TITLE
Make Spyder be recognized as a Jupyter environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed initial blank lines removed from Syntax https://github.com/willmcgugan/rich/issues/1214
 - Added Console.measure as a convenient alias for Measurement.get
 - Added support for pretty printing attrs objects
+- Added support for Spyder
 
 ## [10.1.0] - 2020-04-03
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ The following people have contributed to the development of Rich:
 - [Will McGugan](https://github.com/willmcgugan)
 - [Nathan Page](https://github.com/nathanrpage97)
 - [Clément Robert](https://github.com/neutrinoceros)
+- [Carlos Cordoba](https://github.com/ccordoba12)

--- a/rich/console.py
+++ b/rich/console.py
@@ -459,8 +459,11 @@ def _is_jupyter() -> bool:  # pragma: no cover
         return False
     ipython = get_ipython()  # type: ignore
     shell = ipython.__class__.__name__  # type: ignore
-    if "google.colab" in str(ipython.__class__) or shell == "ZMQInteractiveShell":
-        return True  # Jupyter notebook or qtconsole
+    if "google.colab" in str(ipython.__class__) or shell in [
+        "ZMQInteractiveShell",
+        "SpyderShell",
+    ]:
+        return True  # Jupyter notebook, qtconsole or Spyder
     elif shell == "TerminalInteractiveShell":
         return False  # Terminal running IPython
     else:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

- This detects Spyder as a Jupyter environment.
- Spyder uses qtconsole for its main console, but with a lot of customizations on top of it to connect it to its other panes (including a subclass of ZMQInteractiveShell).
- That's why it was not recognized by Rich as a Jupyter environment.
- This is a much simpler and less invasive change than PR #1218.
