### PR TITLE
perf(console): avoid call to inspect.stack when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.2.3] - 2021-06-05
+
+### Changed
+
+- Changed the logic for retrieving the calling frame in console logs to a faster one for the Python implementations that support it.
+
 ## [10.2.2] - 2021-05-19
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ The following people have contributed to the development of Rich:
 - [Will McGugan](https://github.com/willmcgugan)
 - [Nathan Page](https://github.com/nathanrpage97)
 - [Clément Robert](https://github.com/neutrinoceros)
+- [Gabriele N. Tornetta](https://github.com/p403n1x87)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -45,6 +45,13 @@ def test_log():
     assert rendered == expected
 
 
+def test_log_caller_frame_info():
+    for i in range(2):
+        assert Console._caller_frame_info(i) == Console._caller_frame_info(
+            i, lambda: None
+        )
+
+
 def test_justify():
     console = Console(width=20, log_path=False, log_time=False, color_system=None)
     console.begin_capture()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other (performance)

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] ~~I've added tests for new code.~~
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This change improves the performance of the `Console.log` method by avoiding an expensive call to `stack()` and using `currentframe` instead. The same information is then available by navigating backward as many levels as required and peeking at the `code` object.