### PR TITLE
Exploratory Contribution: MUD Support (MXP/Pueblo)

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -141,6 +141,12 @@ class ConsoleOptions:
     """Enable markup when rendering strings."""
     height: Optional[int] = None
     """Height available, or None for no height limit."""
+    mxp: Optional[bool] = False
+    """Enable MXP/MUD HTML when printing. For MUDs only."""
+    pueblo: Optional[bool] = False
+    """Enable Pueblo/MUD HTML when printing. For MUDs only."""
+    links: Optional[bool] = True
+    """Enable ANSI Links when printing. Turn off if MXP/Pueblo is on."""
 
     @property
     def ascii_only(self) -> bool:
@@ -169,6 +175,9 @@ class ConsoleOptions:
         highlight: Union[Optional[bool], NoChange] = NO_CHANGE,
         markup: Union[Optional[bool], NoChange] = NO_CHANGE,
         height: Union[Optional[int], NoChange] = NO_CHANGE,
+        mxp: Union[Optional[bool], NoChange] = NO_CHANGE,
+        pueblo: Union[Optional[bool], NoChange] = NO_CHANGE,
+        links: Union[Optional[bool], NoChange] = NO_CHANGE,
     ) -> "ConsoleOptions":
         """Update values, return a copy."""
         options = self.copy()
@@ -190,6 +199,12 @@ class ConsoleOptions:
             options.markup = markup
         if not isinstance(height, NoChange):
             options.height = None if height is None else max(0, height)
+        if not isinstance(mxp, NoChange):
+            options.mxp = mxp
+        if not isinstance(pueblo, NoChange):
+            options.pueblo = pueblo
+        if not isinstance(links, NoChange):
+            options.links = links
         return options
 
     def update_width(self, width: int) -> "ConsoleOptions":
@@ -581,6 +596,9 @@ class Console:
         markup (bool, optional): Boolean to enable :ref:`console_markup`. Defaults to True.
         emoji (bool, optional): Enable emoji code. Defaults to True.
         highlight (bool, optional): Enable automatic highlighting. Defaults to True.
+        mxp (bool, optional): Enable MXP mode for MUDs. Defaults to False.
+        pueblo (bool, optional): Enable Pueblo mode for MUDs. Defaults to False.
+        links (bool, optional): Enable Console Links. Defaults to True.
         log_time (bool, optional): Boolean to enable logging of time by :meth:`log` methods. Defaults to True.
         log_path (bool, optional): Boolean to enable the logging of the caller by :meth:`log`. Defaults to True.
         log_time_format (Union[str, TimeFormatterCallable], optional): If ``log_time`` is enabled, either string for strftime or callable that formats the time. Defaults to "[%X] ".
@@ -617,6 +635,9 @@ class Console:
         markup: bool = True,
         emoji: bool = True,
         highlight: bool = True,
+        mxp: bool = False,
+        pueblo: bool = False,
+        links: bool = True,
         log_time: bool = True,
         log_path: bool = True,
         log_time_format: Union[str, FormatTimeCallable] = "[%X]",
@@ -653,6 +674,9 @@ class Console:
         self._markup = markup
         self._emoji = emoji
         self._highlight = highlight
+        self._mxp = mxp
+        self._pueblo = pueblo
+        self._links = links
         self.legacy_windows: bool = (
             (detect_legacy_windows() and not self.is_jupyter)
             if legacy_windows is None
@@ -1505,6 +1529,9 @@ class Console:
         emoji: Optional[bool] = None,
         markup: Optional[bool] = None,
         highlight: Optional[bool] = None,
+        mxp: Optional[bool] = None,
+        pueblo: Optional[bool] = None,
+        links: Optional[bool] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
         crop: bool = True,
@@ -1523,6 +1550,9 @@ class Console:
             emoji (Optional[bool], optional): Enable emoji code, or ``None`` to use console default. Defaults to ``None``.
             markup (Optional[bool], optional): Enable markup, or ``None`` to use console default. Defaults to ``None``.
             highlight (Optional[bool], optional): Enable automatic highlighting, or ``None`` to use console default. Defaults to ``None``.
+            mxp (Optional[bool], optional): Enable MXP, or ``None`` to use console default. Defaults to ``None``.
+            pueblo (Optional[bool], optional): Enable Pueblo, or ``None`` to use console default. Defaults to ``None``.
+            links (Optional[bool], optional): Enable terminal links, or ``None`` to use console default. Defaults to ``None``.
             width (Optional[int], optional): Width of output, or ``None`` to auto-detect. Defaults to ``None``.
             crop (Optional[bool], optional): Crop output to width of terminal. Defaults to True.
             soft_wrap (bool, optional): Enable soft wrap mode which disables word wrapping and cropping of text or None for
@@ -1559,6 +1589,9 @@ class Console:
                 height=height,
                 no_wrap=no_wrap,
                 markup=markup,
+                mxp=mxp,
+                pueblo=pueblo,
+                links=links
             )
 
             new_segments: List[Segment] = []
@@ -1829,6 +1862,9 @@ class Console:
                         text,
                         color_system=color_system,
                         legacy_windows=legacy_windows,
+                        mxp=self._mxp,
+                        pueblo=self._pueblo,
+                        links=self._links
                     )
                 )
             elif not (not_terminal and control):

--- a/rich/console.py
+++ b/rich/console.py
@@ -1591,7 +1591,7 @@ class Console:
                 markup=markup,
                 mxp=mxp,
                 pueblo=pueblo,
-                links=links
+                links=links,
             )
 
             new_segments: List[Segment] = []
@@ -1864,7 +1864,7 @@ class Console:
                         legacy_windows=legacy_windows,
                         mxp=self._mxp,
                         pueblo=self._pueblo,
-                        links=self._links
+                        links=self._links,
                     )
                 )
             elif not (not_terminal and control):

--- a/rich/style.py
+++ b/rich/style.py
@@ -669,7 +669,9 @@ class Style:
         text = text or str(self)
         sys.stdout.write(f"{self.render(text)}\n")
 
-    def __add__(self, style: Optional["Style"]) -> "Style":
+    def __add__(self, style: Union["Style", str]) -> "Style":
+        if isinstance(style, str):
+            style = self.__class__.parse(style)
         if not (isinstance(style, Style) or style is None):
             return NotImplemented
         if style is None or style._null:
@@ -694,6 +696,12 @@ class Style:
         new_style._null = self._null or style._null
 
         return new_style
+
+    def __radd__(self, other):
+        if isinstance(other, str):
+            other = self.__class__.parse(other)
+            return other + self
+        return NotImplemented
 
     def serialize(self) -> dict:
         attrs = (

--- a/rich/style.py
+++ b/rich/style.py
@@ -67,7 +67,7 @@ class Style:
         "_null",
         "_tag",
         "_xml_attr",
-        "_xml_attr_data"
+        "_xml_attr_data",
     ]
 
     # maps bits on to SGR parameter
@@ -107,7 +107,7 @@ class Style:
         overline: Optional[bool] = None,
         link: Optional[str] = None,
         tag: Optional[str] = None,
-        xml_attr: Optional[Dict] = None
+        xml_attr: Optional[Dict] = None,
     ):
         self._ansi: Optional[str] = None
         self._style_definition: Optional[str] = None
@@ -115,9 +115,13 @@ class Style:
         self._tag = tag
         self._xml_attr = xml_attr
         if self._xml_attr:
-            self._xml_attr_data = ' '.join(f'{k}="{html.escape(v)}"' for k, v in xml_attr.items()) if xml_attr else ''
+            self._xml_attr_data = (
+                " ".join(f'{k}="{html.escape(v)}"' for k, v in xml_attr.items())
+                if xml_attr
+                else ""
+            )
         else:
-            self._xml_attr_data = ''
+            self._xml_attr_data = ""
 
         def _make_color(color: Union[Color, str]) -> Color:
             return color if isinstance(color, Color) else Color.parse(color)
@@ -615,7 +619,7 @@ class Style:
         legacy_windows: bool = False,
         mxp: bool = False,
         pueblo: bool = False,
-        links: bool = True
+        links: bool = True,
     ) -> str:
         """Render the ANSI codes for the style.
 
@@ -635,7 +639,9 @@ class Style:
         else:
             rendered = out_text
         if links and self._link and not legacy_windows:
-            rendered = f"\x1b]8;id={self._link_id};{self._link}\x1b\\{rendered}\x1b]8;;\x1b\\"
+            rendered = (
+                f"\x1b]8;id={self._link_id};{self._link}\x1b\\{rendered}\x1b]8;;\x1b\\"
+            )
         if (pueblo or mxp) and self._tag:
             if mxp:
                 if self._xml_attr:
@@ -644,7 +650,9 @@ class Style:
                     rendered = f"\x1b[4z<{self._tag}>{rendered}\x1b[4z</{self._tag}>"
             else:
                 if self._xml_attr:
-                    rendered = f"{self._tag} {self._xml_attr_data}>{rendered}</{self._tag}>"
+                    rendered = (
+                        f"{self._tag} {self._xml_attr_data}>{rendered}</{self._tag}>"
+                    )
                 else:
                     rendered = f"<{self._tag}>{rendered}</{self._tag}>"
         return rendered
@@ -688,8 +696,26 @@ class Style:
         return new_style
 
     def serialize(self) -> dict:
-        attrs = ('color', 'bgcolor', 'bold', 'dim', 'italic', 'underline', 'blink', 'blink2', 'reverse', 'conceal',
-                 'strike', 'underline2', 'frame', 'encircle', 'overline', 'link', 'tag', 'xml_attr')
+        attrs = (
+            "color",
+            "bgcolor",
+            "bold",
+            "dim",
+            "italic",
+            "underline",
+            "blink",
+            "blink2",
+            "reverse",
+            "conceal",
+            "strike",
+            "underline2",
+            "frame",
+            "encircle",
+            "overline",
+            "link",
+            "tag",
+            "xml_attr",
+        )
 
         out = dict()
 

--- a/rich/text.py
+++ b/rich/text.py
@@ -189,7 +189,7 @@ class Text(JupyterMixin):
             return self.copy()
         if other > 1:
             out = self.copy()
-            for i in range(other-1):
+            for i in range(other - 1):
                 out.append(self)
             return out
 
@@ -1224,11 +1224,11 @@ class Text(JupyterMixin):
     def isupper(self):
         return self.plain.isupper()
 
-    def center(self, width, fillchar=' '):
+    def center(self, width, fillchar=" "):
         changed = self.plain.center(width, fillchar)
         start = changed.find(self.plain)
         lside = changed[:start]
-        rside = changed[len(lside)+len(self.plain):]
+        rside = changed[len(lside) + len(self.plain) :]
         idx = self.disassemble_bits()
         new_idx = list()
         for c in lside:
@@ -1238,7 +1238,7 @@ class Text(JupyterMixin):
             new_idx.append((None, c))
         return self.__class__.assemble_bits(new_idx)
 
-    def ljust(self, width: int, fillchar: Union[str, "MudText"] = ' '):
+    def ljust(self, width: int, fillchar: Union[str, "MudText"] = " "):
         diff = width - len(self)
         out = self.copy()
         if diff <= 0:
@@ -1249,7 +1249,7 @@ class Text(JupyterMixin):
             out.append(fillchar * diff)
             return out
 
-    def rjust(self, width: int, fillchar: Union[str, "MudText"] = ' '):
+    def rjust(self, width: int, fillchar: Union[str, "MudText"] = " "):
         diff = width - len(self)
         if diff <= 0:
             return self.copy()
@@ -1265,7 +1265,7 @@ class Text(JupyterMixin):
         strip_count = len(self.plain) - len(lstripped)
         return self[strip_count:]
 
-    def strip(self, chars: str = ' '):
+    def strip(self, chars: str = " "):
         out_map = self.disassemble_bits()
         for i, e in enumerate(out_map):
             if e[1] != chars:
@@ -1306,7 +1306,9 @@ class Text(JupyterMixin):
             elif new_len > old_len:
                 # slightly complex. insert new characters.
                 for i in range(diff):
-                    other_map.insert(idx + old_len + i, (final_markup, new[old_len + i]))
+                    other_map.insert(
+                        idx + old_len + i, (final_markup, new[old_len + i])
+                    )
 
         return self.__class__.assemble_bits(other_map)
 
@@ -1365,22 +1367,20 @@ class Text(JupyterMixin):
             if not span.style:
                 return None
             return {
-                'start': span.start,
-                'end': span.end,
-                'style': ser_style(span.style)
+                "start": span.start,
+                "end": span.end,
+                "style": ser_style(span.style),
             }
 
-        out = {
-            "text": self.plain
-        }
+        out = {"text": self.plain}
 
         if self.style:
-            out['style'] = ser_style(self.style)
+            out["style"] = ser_style(self.style)
 
         out_spans = [s for span in self.spans if (s := ser_span(span))]
 
         if out_spans:
-            out['spans'] = out_spans
+            out["spans"] = out_spans
 
         return out
 
@@ -1396,7 +1396,7 @@ class Text(JupyterMixin):
         spans = data.get("spans", None)
 
         if spans:
-            spans = [Span(s['start'], s['end'], Style(**s['style'])) for s in spans]
+            spans = [Span(s["start"], s["end"], Style(**s["style"])) for s in spans]
 
         return cls(text=text, style=style, spans=spans)
 
@@ -1408,7 +1408,7 @@ class Text(JupyterMixin):
         out = list()
         matches = _RE_SQUISH.finditer(self.plain)
         for match in matches:
-            out.append(self[match.start():match.end()])
+            out.append(self[match.start() : match.end()])
         return self.__class__(" ").join(out)
 
     def squish_spaces(self) -> "MudText":
@@ -1418,8 +1418,9 @@ class Text(JupyterMixin):
         out = list()
         matches = _RE_NOTSPACE.finditer(self.plain)
         for match in matches:
-            out.append(self[match.start():match.end()])
+            out.append(self[match.start() : match.end()])
         return self.__class__(" ").join(out)
+
 
 if __name__ == "__main__":  # pragma: no cover
     from rich.console import Console

--- a/rich/text.py
+++ b/rich/text.py
@@ -1,4 +1,5 @@
 import re
+import random
 from functools import partial, reduce
 from math import gcd
 from operator import attrgetter, itemgetter
@@ -34,6 +35,8 @@ if TYPE_CHECKING:  # pragma: no cover
 DEFAULT_JUSTIFY: "JustifyMethod" = "default"
 DEFAULT_OVERFLOW: "OverflowMethod" = "fold"
 
+_RE_SQUISH = re.compile("\S+")
+_RE_NOTSPACE = re.compile("[^ ]+")
 
 _re_whitespace = re.compile(r"\s+$")
 
@@ -165,6 +168,36 @@ class Text(JupyterMixin):
             return result
         return NotImplemented
 
+    def __radd__(self, other):
+        if isinstance(other, str):
+            other = self.__class__(text=other)
+            return other + self
+        return NotImplemented
+
+    def __iadd__(self, other: Any) -> "Text":
+        if isinstance(other, (str, Text)):
+            self.append(other)
+            return self
+        return NotImplemented
+
+    def __mul__(self, other):
+        if not isinstance(other, int):
+            return self
+        if other <= 0:
+            return self.__class__()
+        if other == 1:
+            return self.copy()
+        if other > 1:
+            out = self.copy()
+            for i in range(other-1):
+                out.append(self)
+            return out
+
+    def __rmul__(self, other):
+        if not isinstance(other, int):
+            return self
+        return self * other
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Text):
             return NotImplemented
@@ -202,6 +235,12 @@ class Text(JupyterMixin):
                 # This would be a bit of work to implement efficiently
                 # For now, its not required
                 raise TypeError("slices with step!=1 are not supported")
+
+    def __format__(self, format_spec):
+        """
+        Allows use of f-strings, although styling is not preserved.
+        """
+        return self.plain.__format__(format_spec)
 
     @property
     def cell_len(self) -> int:
@@ -1132,6 +1171,255 @@ class Text(JupyterMixin):
         new_text = text.blank_copy("\n").join(new_lines)
         return new_text
 
+    # Begin implementing Python String Api below...
+
+    def capitalize(self):
+        return self.__class__(text=self.plain.capitalize(), spans=list(self.spans))
+
+    def count(self, *args, **kwargs):
+        return self.plain.count(*args, **kwargs)
+
+    def startswith(self, *args, **kwargs):
+        return self.plain.startswith(*args, **kwargs)
+
+    def endswith(self, *args, **kwargs):
+        return self.plain.endswith(*args, **kwargs)
+
+    def find(self, *args, **kwargs):
+        return self.plain.find(*args, **kwargs)
+
+    def index(self, *args, **kwargs):
+        return self.plain.index(*args, **kwargs)
+
+    def isalnum(self):
+        return self.plain.isalnum()
+
+    def isalpha(self):
+        return self.plain.isalpha()
+
+    def isdecimal(self):
+        return self.plain.isdecimal()
+
+    def isdigit(self):
+        return self.plain.isdigit()
+
+    def isidentifier(self):
+        return self.plain.isidentifier()
+
+    def islower(self):
+        return self.plain.islower()
+
+    def isnumeric(self):
+        return self.plain.isnumeric()
+
+    def isprintable(self):
+        return self.plain.isprintable()
+
+    def isspace(self):
+        return self.plain.isspace()
+
+    def istitle(self):
+        return self.plain.istitle()
+
+    def isupper(self):
+        return self.plain.isupper()
+
+    def center(self, width, fillchar=' '):
+        changed = self.plain.center(width, fillchar)
+        start = changed.find(self.plain)
+        lside = changed[:start]
+        rside = changed[len(lside)+len(self.plain):]
+        idx = self.disassemble_bits()
+        new_idx = list()
+        for c in lside:
+            new_idx.append((None, c))
+        new_idx.extend(idx)
+        for c in rside:
+            new_idx.append((None, c))
+        return self.__class__.assemble_bits(new_idx)
+
+    def ljust(self, width: int, fillchar: Union[str, "MudText"] = ' '):
+        diff = width - len(self)
+        out = self.copy()
+        if diff <= 0:
+            return out
+        else:
+            if isinstance(fillchar, str):
+                fillchar = self.__class__(fillchar)
+            out.append(fillchar * diff)
+            return out
+
+    def rjust(self, width: int, fillchar: Union[str, "MudText"] = ' '):
+        diff = width - len(self)
+        if diff <= 0:
+            return self.copy()
+        else:
+            if isinstance(fillchar, str):
+                fillchar = self.__class__(fillchar)
+            out = fillchar * diff
+            out.append(self)
+            return out
+
+    def lstrip(self, chars: str = None):
+        lstripped = self.plain.lstrip(chars)
+        strip_count = len(self.plain) - len(lstripped)
+        return self[strip_count:]
+
+    def strip(self, chars: str = ' '):
+        out_map = self.disassemble_bits()
+        for i, e in enumerate(out_map):
+            if e[1] != chars:
+                out_map = out_map[i:]
+                break
+        out_map.reverse()
+        for i, e in enumerate(out_map):
+            if e[1] != chars:
+                out_map = out_map[i:]
+                break
+        out_map.reverse()
+        return self.__class__.assemble_bits(out_map)
+
+    def replace(self, old: str, new: Union[str, "Text"], count=None) -> "Text":
+        if not (indexes := self.find_all(old)):
+            return self.clone()
+        if count and count > 0:
+            indexes = indexes[:count]
+        old_len = len(old)
+        new_len = len(new)
+        other = self.clone()
+        markup_idx_map = self.disassemble_bits()
+        other_map = other.disassemble_bits()
+
+        for idx in reversed(indexes):
+            final_markup = markup_idx_map[idx + old_len][0]
+            diff = abs(old_len - new_len)
+            replace_chars = min(new_len, old_len)
+            # First, replace any characters that overlap.
+            for i in range(replace_chars):
+                other_map[idx + i] = (markup_idx_map[idx + i][0], new[i])
+            if old_len == new_len:
+                pass  # the nicest case. nothing else needs doing.
+            elif old_len > new_len:
+                # slightly complex. pop off remaining characters.
+                for i in range(diff):
+                    deleted = other_map.pop(idx + new_len)
+            elif new_len > old_len:
+                # slightly complex. insert new characters.
+                for i in range(diff):
+                    other_map.insert(idx + old_len + i, (final_markup, new[old_len + i]))
+
+        return self.__class__.assemble_bits(other_map)
+
+    def find_all(self, sub: str):
+        indexes = list()
+        start = 0
+        while True:
+            start = self.plain.find(sub, start)
+            if start == -1:
+                return indexes
+            indexes.append(start)
+            start += len(sub)
+
+    def scramble(self):
+        idx = self.disassemble_bits()
+        random.shuffle(idx)
+        return self.__class__.assemble_bits(idx)
+
+    def reverse(self):
+        idx = self.disassemble_bits()
+        idx.reverse()
+        return self.__class__.assemble_bits(idx)
+
+    @classmethod
+    def assemble_bits(cls, idx: List[Tuple[Optional[Union[str, Style, None]], str]]):
+        out = cls()
+        for i, t in enumerate(idx):
+            s = [Span(0, 1, t[0])]
+            out.append_text(cls(text=t[1], spans=s))
+        return out
+
+    def style_at_index(self, offset: int) -> Style:
+        if offset < 0:
+            offset = len(self) + offset
+        style = Style.null()
+        for start, end, span_style in self._spans:
+            if end > offset >= start:
+                style = style + span_style
+        return style
+
+    def disassemble_bits(self) -> List[Tuple[Optional[Union[str, Style, None]], str]]:
+        idx = list()
+        for i, c in enumerate(self.plain):
+            idx.append((self.style_at_index(i), c))
+        return idx
+
+    def serialize(self) -> dict:
+        def ser_style(style):
+            if isinstance(style, str):
+                style = Style.parse(style)
+            if not isinstance(style, Style):
+                style = Style.upgrade(style)
+            return style.serialize()
+
+        def ser_span(span):
+            if not span.style:
+                return None
+            return {
+                'start': span.start,
+                'end': span.end,
+                'style': ser_style(span.style)
+            }
+
+        out = {
+            "text": self.plain
+        }
+
+        if self.style:
+            out['style'] = ser_style(self.style)
+
+        out_spans = [s for span in self.spans if (s := ser_span(span))]
+
+        if out_spans:
+            out['spans'] = out_spans
+
+        return out
+
+    @classmethod
+    def deserialize(cls, data) -> "Text":
+        text = data.get("text", None)
+        if text is None:
+            return cls("")
+        style = data.get("style", None)
+        if style:
+            style = Style(**style)
+
+        spans = data.get("spans", None)
+
+        if spans:
+            spans = [Span(s['start'], s['end'], Style(**s['style'])) for s in spans]
+
+        return cls(text=text, style=style, spans=spans)
+
+    def squish(self) -> "MudText":
+        """
+        Removes leading and trailing whitespace, and coerces all internal whitespace sequences
+        into at most a single space. Returns the results.
+        """
+        out = list()
+        matches = _RE_SQUISH.finditer(self.plain)
+        for match in matches:
+            out.append(self[match.start():match.end()])
+        return self.__class__(" ").join(out)
+
+    def squish_spaces(self) -> "MudText":
+        """
+        Like squish, but retains newlines and tabs. Just squishes spaces.
+        """
+        out = list()
+        matches = _RE_NOTSPACE.finditer(self.plain)
+        for match in matches:
+            out.append(self[match.start():match.end()])
+        return self.__class__(" ").join(out)
 
 if __name__ == "__main__":  # pragma: no cover
     from rich.console import Console

--- a/rich/text.py
+++ b/rich/text.py
@@ -1174,7 +1174,7 @@ class Text(JupyterMixin):
     # Begin implementing Python String Api below...
 
     def capitalize(self):
-        return self.__class__(text=self.plain.capitalize(), spans=list(self.spans))
+        return self.__class__(text=self.plain.capitalize(), style=self.style, spans=list(self.spans))
 
     def count(self, *args, **kwargs):
         return self.plain.count(*args, **kwargs)

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -31,6 +31,7 @@ from .style import Style
 from .syntax import Syntax
 from .text import Text
 from .theme import Theme
+from .box import Box, ROUNDED
 
 WINDOWS = platform.system() == "Windows"
 
@@ -211,6 +212,7 @@ class Traceback:
         word_wrap: bool = False,
         show_locals: bool = False,
         indent_guides: bool = True,
+        box: Box = ROUNDED,
         locals_max_length: int = LOCALS_MAX_LENGTH,
         locals_max_string: int = LOCALS_MAX_STRING,
     ):
@@ -232,6 +234,7 @@ class Traceback:
         self.indent_guides = indent_guides
         self.locals_max_length = locals_max_length
         self.locals_max_string = locals_max_string
+        self.box = box
 
     @classmethod
     def from_exception(
@@ -245,6 +248,7 @@ class Traceback:
         word_wrap: bool = False,
         show_locals: bool = False,
         indent_guides: bool = True,
+        box: Box = ROUNDED,
         locals_max_length: int = LOCALS_MAX_LENGTH,
         locals_max_string: int = LOCALS_MAX_STRING,
     ) -> "Traceback":
@@ -278,6 +282,7 @@ class Traceback:
             word_wrap=word_wrap,
             show_locals=show_locals,
             indent_guides=indent_guides,
+            box=box,
             locals_max_length=locals_max_length,
             locals_max_string=locals_max_string,
         )
@@ -420,6 +425,7 @@ class Traceback:
             if stack.frames:
                 stack_renderable: ConsoleRenderable = Panel(
                     self._render_stack(stack),
+                    box=self.box,
                     title="[traceback.title]Traceback [dim](most recent call last)",
                     style=background_style,
                     border_style="traceback.border.syntax_error",


### PR DESCRIPTION
I don't expect this Pull Request to pass as-is. It would definitely need a bit more polish for that. But see the description!

Basically, I'm looking for input on whether this SORT of contribution would be desired, before I commit to going further.

Please let me know if it's not; then I might have to fork. I tried to integrate these features via monkey-patching, but it caused a lot of problems.

## Type of changes

- [ ] Bug fix
- [X ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

This patch would add support for MXP (Mud eXtension Protocol) and Pueblo. This required some minor edits to Text, Style, and Console. Because I'm working on a project that relies heavily on Text objects and treating them largely like normal strings, the Text object API was also expanded to handle much more of the Python String API.

Also added the ability to specify BOX type for Traceback printing, because the default one looks terrible in monospace MUD setups.