### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,10 @@
+name: codespell
+on: [pull_request, push]
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: python3 -m pip install codespell
+      - run: codespell --ignore-words-list="ba,fo,hel,revered,womens"
+          --skip="./README.de.md,./README.es.md,./README.sv.md,*.svg"

--- a/docs/source/console.rst
+++ b/docs/source/console.rst
@@ -284,7 +284,7 @@ Paging
 
 If you have some long output to present to the user you can use a *pager* to display it. A pager is typically an application on your operating system which will at least support pressing a key to scroll, but will often support scrolling up and down through the text and other features.
 
-You can page output from a Console by calling :meth:`~rich.console.Console.pager` which returns a context manger. When the pager exits, anything that was printed will be sent to the pager. Here's an example::
+You can page output from a Console by calling :meth:`~rich.console.Console.pager` which returns a context manager. When the pager exits, anything that was printed will be sent to the pager. Here's an example::
 
     from rich.__main__ import make_test_card
     from rich.console import Console

--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -192,7 +192,7 @@ If the :class:`~rich.progress.Progress` class doesn't offer exactly what you nee
 Multiple Progress
 -----------------
 
-You can't have different columns per task with a single Progress instance. However, you can have as many Progress instance as you like in a :ref:`live`. See `live_progress.py <https://github.com/willmcgugan/rich/blob/master/examples/live_progress.py>`_ for an example of using mutiple Progress instances.
+You can't have different columns per task with a single Progress instance. However, you can have as many Progress instance as you like in a :ref:`live`. See `live_progress.py <https://github.com/willmcgugan/rich/blob/master/examples/live_progress.py>`_ for an example of using multiple Progress instances.
 
 Example
 -------

--- a/rich/color_triplet.py
+++ b/rich/color_triplet.py
@@ -29,7 +29,7 @@ class ColorTriplet(NamedTuple):
 
     @property
     def normalized(self) -> Tuple[float, float, float]:
-        """Covert components in to floats between 0 and 1.
+        """Convert components into floats between 0 and 1.
 
         Returns:
             Tuple[float, float, float]: A tuple of three normalized colour components.

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -589,7 +589,7 @@ def traverse(
             and not isinstance(obj, type)
             and (
                 "__create_fn__" in obj.__repr__.__qualname__ or py_version == (3, 6)
-            )  # Check if __repr__ wasn't overriden
+            )  # Check if __repr__ wasn't overridden
         ):
             obj_id = id(obj)
             if obj_id in visited_ids:

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -473,7 +473,7 @@ class Task:
     """Optional[float]: Time this task was stopped, or None if not stopped."""
 
     finished_speed: Optional[float] = None
-    """Optional[float]: The last speed for a finshed task."""
+    """Optional[float]: The last speed for a finished task."""
 
     _progress: Deque[ProgressSample] = field(
         default_factory=deque, init=False, repr=False

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -115,7 +115,7 @@ class SyntaxTheme(ABC):
 
 
 class PygmentsSyntaxTheme(SyntaxTheme):
-    """Syntax theme that delagates to Pygments theme."""
+    """Syntax theme that delegates to Pygments theme."""
 
     def __init__(self, theme: Union[str, Type[PygmentsStyle]]) -> None:
         self._style_cache: Dict[TokenType, Style] = {}
@@ -679,7 +679,7 @@ if __name__ == "__main__":  # pragma: no cover
         "--background-color",
         dest="background_color",
         default=None,
-        help="Overide background color",
+        help="Override background color",
     )
     parser.add_argument(
         "-x",

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -133,12 +133,12 @@ def install(
         # if wihin ipython, use customized traceback
         ip = get_ipython()  # type: ignore
         ipy_excepthook_closure(ip)
-        return sys.excepthook  # type: ignore # more strict signature that mypy cant interpret
+        return sys.excepthook  # type: ignore # more strict signature that mypy can't interpret
     except Exception:
         # otherwise use default system hook
         old_excepthook = sys.excepthook
         sys.excepthook = excepthook
-        return old_excepthook  # type: ignore # more strict signature that mypy cant interpret
+        return old_excepthook  # type: ignore # more strict signature that mypy can't interpret
 
 
 @dataclass

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -407,7 +407,7 @@ def test_reset() -> None:
 
 
 def test_progress_max_refresh() -> None:
-    """Test max_refresh argment."""
+    """Test max_refresh argument."""
     time = 0.0
 
     def get_time() -> float:

--- a/tools/cats.json
+++ b/tools/cats.json
@@ -240,7 +240,7 @@
         },
         {
             "_id": "5955792c7b77520020799431",
-            "text": "Cats \"knead\" because of seperation from their mothers",
+            "text": "Cats \"knead\" because of separation from their mothers",
             "type": "cat",
             "user": {
                 "_id": "595579027b77520020799430",
@@ -3202,7 +3202,7 @@
         {
             "_id": "5d38bcc00f1c57001592f153",
             "type": "cat",
-            "text": "The irresistable and cuddly Ragamuffin is the result of crossbreeding Ragdoll cats with Persians, Himalayans, and other larger longhaired breeds.",
+            "text": "The irresistible and cuddly Ragamuffin is the result of crossbreeding Ragdoll cats with Persians, Himalayans, and other larger longhaired breeds.",
             "user": {
                 "_id": "5a9ac18c7478810ea6c06381",
                 "name": {


### PR DESCRIPTION
## Type of changes

- [x] Typo fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
Create a GitHub Action (runtime ~8 sec.) to use [codespell](https://github.com/codespell-project/codespell) to discover typos.
Output: https://github.com/cclauss/rich/actions
