### PR TITLE
Decimal formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.6.0] - Unreleased
+
+### Added
+
+- Added precision argument to filesize.decimal
+- Added separator argument to filesize.decimal
+
 ## [10.5.0] - 2021-05-07
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@ The following people have contributed to the development of Rich:
 
 <!-- Add your name below, sort alphabetically by surname. Link to Github profile / your home page. -->
 
+- [Pete Davison](https://github.com/pd93)
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Finn Hughes](https://github.com/finnhughes)
 - [Josh Karpel](https://github.com/JoshKarpel)

--- a/rich/filesize.py
+++ b/rich/filesize.py
@@ -13,15 +13,15 @@ See Also:
 
 __all__ = ["decimal"]
 
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Tuple, Optional
 
 
 def _to_str(
     size: int,
     suffixes: Iterable[str],
     base: int,
-    precision: int = 1,
-    separator: str = " ",
+    precision: Optional[int] = 1,
+    separator: Optional[str] = " ",
 ) -> str:
     if size == 1:
         return "1 byte"
@@ -49,7 +49,7 @@ def pick_unit_and_suffix(size: int, suffixes: List[str], base: int) -> Tuple[int
     return unit, suffix
 
 
-def decimal(size: int, precision: int = 1, separator: str = " ") -> str:
+def decimal(size: int, precision: Optional[int] = 1, separator: Optional[str] = " ") -> str:
     """Convert a filesize in to a string (powers of 1000, SI prefixes).
 
     In this convention, ``1000 B = 1 kB``.

--- a/rich/filesize.py
+++ b/rich/filesize.py
@@ -16,7 +16,13 @@ __all__ = ["decimal"]
 from typing import Iterable, List, Tuple
 
 
-def _to_str(size: int, suffixes: Iterable[str], base: int, precision: int = 1, separator: str = " ") -> str:
+def _to_str(
+    size: int,
+    suffixes: Iterable[str],
+    base: int,
+    precision: int = 1,
+    separator: str = " ",
+) -> str:
     if size == 1:
         return "1 byte"
     elif size < base:
@@ -26,7 +32,12 @@ def _to_str(size: int, suffixes: Iterable[str], base: int, precision: int = 1, s
         unit = base ** i
         if size < unit:
             break
-    return "{:,.{precision}f}{separator}{}".format((base * size / unit), suffix, precision=precision, separator=separator)
+    return "{:,.{precision}f}{separator}{}".format(
+        (base * size / unit),
+        suffix,
+        precision=precision,
+        separator=separator,
+    )
 
 
 def pick_unit_and_suffix(size: int, suffixes: List[str], base: int) -> Tuple[int, str]:
@@ -63,4 +74,10 @@ def decimal(size: int, precision: int = 1, separator: str = " ") -> str:
         '30.00kB'
 
     """
-    return _to_str(size, ("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"), 1000, precision=precision, separator=separator)
+    return _to_str(
+        size,
+        ("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"),
+        1000,
+        precision=precision,
+        separator=separator,
+    )

--- a/rich/filesize.py
+++ b/rich/filesize.py
@@ -49,7 +49,11 @@ def pick_unit_and_suffix(size: int, suffixes: List[str], base: int) -> Tuple[int
     return unit, suffix
 
 
-def decimal(size: int, precision: Optional[int] = 1, separator: Optional[str] = " ") -> str:
+def decimal(
+    size: int,
+    precision: Optional[int] = 1,
+    separator: Optional[str] = " ",
+) -> str:
     """Convert a filesize in to a string (powers of 1000, SI prefixes).
 
     In this convention, ``1000 B = 1 kB``.

--- a/rich/filesize.py
+++ b/rich/filesize.py
@@ -20,6 +20,7 @@ def _to_str(
     size: int,
     suffixes: Iterable[str],
     base: int,
+    *,
     precision: Optional[int] = 1,
     separator: Optional[str] = " ",
 ) -> str:
@@ -51,6 +52,7 @@ def pick_unit_and_suffix(size: int, suffixes: List[str], base: int) -> Tuple[int
 
 def decimal(
     size: int,
+    *,
     precision: Optional[int] = 1,
     separator: Optional[str] = " ",
 ) -> str:

--- a/rich/filesize.py
+++ b/rich/filesize.py
@@ -16,7 +16,7 @@ __all__ = ["decimal"]
 from typing import Iterable, List, Tuple
 
 
-def _to_str(size: int, suffixes: Iterable[str], base: int) -> str:
+def _to_str(size: int, suffixes: Iterable[str], base: int, precision: int = 1, separator: str = " ") -> str:
     if size == 1:
         return "1 byte"
     elif size < base:
@@ -26,7 +26,7 @@ def _to_str(size: int, suffixes: Iterable[str], base: int) -> str:
         unit = base ** i
         if size < unit:
             break
-    return "{:,.1f} {}".format((base * size / unit), suffix)
+    return "{:,.{precision}f}{separator}{}".format((base * size / unit), suffix, precision=precision, separator=separator)
 
 
 def pick_unit_and_suffix(size: int, suffixes: List[str], base: int) -> Tuple[int, str]:
@@ -38,7 +38,7 @@ def pick_unit_and_suffix(size: int, suffixes: List[str], base: int) -> Tuple[int
     return unit, suffix
 
 
-def decimal(size: int) -> str:
+def decimal(size: int, precision: int = 1, separator: str = " ") -> str:
     """Convert a filesize in to a string (powers of 1000, SI prefixes).
 
     In this convention, ``1000 B = 1 kB``.
@@ -50,6 +50,8 @@ def decimal(size: int) -> str:
 
     Arguments:
         int (size): A file size.
+        int (precision): The number of decimal places to include (default = 1).
+        str (separator): The string to separate the value from the units (default = " ").
 
     Returns:
         `str`: A string containing a abbreviated file size and units.
@@ -57,6 +59,8 @@ def decimal(size: int) -> str:
     Example:
         >>> filesize.decimal(30000)
         '30.0 kB'
+        >>> filesize.decimal(30000, precision=2, separator="")
+        '30.00kB'
 
     """
-    return _to_str(size, ("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"), 1000)
+    return _to_str(size, ("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"), 1000, precision=precision, separator=separator)

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -7,6 +7,11 @@ def test_traditional():
     assert filesize.decimal(2) == "2 bytes"
     assert filesize.decimal(1000) == "1.0 kB"
     assert filesize.decimal(1.5 * 1000 * 1000) == "1.5 MB"
+    assert filesize.decimal(0, precision=2) == "0 bytes"
+    assert filesize.decimal(1111, precision=0) == "1 kB"
+    assert filesize.decimal(1111, precision=1) == "1.1 kB"
+    assert filesize.decimal(1111, precision=2) == "1.11 kB"
+    assert filesize.decimal(1111, separator="") == "1.1kB"
 
 
 def test_pick_unit_and_suffix():


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Simply adds a couple of optional paramters to the `filesize.decimal()` function that allows the user to set their precision (number of decimal places) and the separator between the value and the units. In my project, I have a utility with this functionality, but I also depend on Rich. It would be great to remove that utility without having to change the filesize formats.

All changes are backward-compatible.
