### PR TITLE
Adds missing prop to `__slots__` of `Emoji`

### DIFF
--- a/rich/emoji.py
+++ b/rich/emoji.py
@@ -25,7 +25,7 @@ class NoEmoji(Exception):
 
 
 class Emoji(JupyterMixin):
-    __slots__ = ["name", "style", "_char"]
+    __slots__ = ["name", "style", "_char", "variant"]
 
     VARIANTS = {"text": "\uFE0E", "emoji": "\uFE0F"}
 

--- a/rich/jupyter.py
+++ b/rich/jupyter.py
@@ -30,6 +30,8 @@ class JupyterRenderable:
 
 class JupyterMixin:
     """Add to an Rich renderable to make it render in Jupyter notebook."""
+    
+    __slots__ = []
 
     def _repr_mimebundle_(
         self, include: Iterable[str], exclude: Iterable[str], **kwargs: Any

--- a/rich/jupyter.py
+++ b/rich/jupyter.py
@@ -31,7 +31,7 @@ class JupyterRenderable:
 class JupyterMixin:
     """Add to an Rich renderable to make it render in Jupyter notebook."""
 
-    __slots__ = []
+    __slots__ = ()
 
     def _repr_mimebundle_(
         self, include: Iterable[str], exclude: Iterable[str], **kwargs: Any

--- a/rich/jupyter.py
+++ b/rich/jupyter.py
@@ -30,7 +30,7 @@ class JupyterRenderable:
 
 class JupyterMixin:
     """Add to an Rich renderable to make it render in Jupyter notebook."""
-    
+
     __slots__ = []
 
     def _repr_mimebundle_(


### PR DESCRIPTION
Refs https://github.com/python/mypy/pull/10864

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This prop was missing from `__slots__` 🙂 

There's one more thing: current `__slots__` setup does not work:

```python
>>> e = Emoji('2nd_place_medal', variant='text')
>>> e.__slots__
['name', 'style', '_char']
>>> e.__dict__
{'variant': 'text', 'a': 1, 'bb': 1}

>>> e.a = 1  # should fail, but does not
>>> e.bb = 1  # should fail, but does not
```

This happens due to the fact that `JupiterMixin` does not have `__slots__ = ()` defined.
I can add it if you wish 🙂 