### PR TITLE
Fix trivial typo and grammar in live docs

### DIFF
--- a/docs/source/live.rst
+++ b/docs/source/live.rst
@@ -5,7 +5,7 @@ Live Display
 
 Progress bars and status indicators use a *live* display to animate parts of the terminal. You can build custom live displays with the :class:`~rich.live.Live` class. 
 
-For a demonstration of a live display, running the following command:
+For a demonstration of a live display, run the following command:
 
     python -m rich.live
 
@@ -16,7 +16,7 @@ For a demonstration of a live display, running the following command:
 Basic usage
 ~~~~~~~~~~~
 
-To create a live display, construct a :class:`~rich.live.Live` object with a renderable and use it has a context manager. The live display will persist for the duration of the context. You can update the renderable to update the display::
+To create a live display, construct a :class:`~rich.live.Live` object with a renderable and use it as a context manager. The live display will persist for the duration of the context. You can update the renderable to update the display::
 
 
     import time


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [X] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [-] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [-] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [-] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes a trivial typo and grammar I found in the live docs while using them.
