### PR TITLE
Improved example code for trackback

### DIFF
--- a/docs/source/traceback.rst
+++ b/docs/source/traceback.rst
@@ -9,11 +9,14 @@ Printing tracebacks
 
 The :meth:`~rich.console.Console.print_exception` method will print a traceback for the current exception being handled. Here's an example::
 
+    import rich
     try:
         do_something()
     except:
-        console.print_exception()
+        console = rich.console.Console()
+        console.print_exception(show_locals=True)
 
+The ``show_locals=True`` parameter causes Rich to display the value of local variables for each section of the traceback.
 
 Traceback handler
 -----------------
@@ -21,6 +24,6 @@ Traceback handler
 Rich can be installed as the default traceback handler so that all uncaught exceptions will be rendered with highlighting. Here's how::
 
     from rich.traceback import install
-    install()
+    install(show_locals=True)
 
 There are a few options to configure the traceback handler, see :func:`~rich.traceback.install` for details.


### PR DESCRIPTION
- Show how to create a `console` object
- Demonstrate the `show_locals=True` parameter

Refs #1380

## Type of changes

- [x] Documentation / docstrings
