### PR TITLE
Optimisation suggestions for Segment.divide()

### DIFF
--- a/rich/segment.py
+++ b/rich/segment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import IntEnum
 from logging import getLogger
 from typing import Dict, NamedTuple, Optional
@@ -472,16 +474,17 @@ class Segment(NamedTuple):
         """
         split_segments: List["Segment"] = []
         add_segment = split_segments.append
-        iter_cuts = iter(cuts)
+        next_cut = iter(cuts).__next__
+        
+        try:
+            while True:
+                cut = next_cut()
+                if cut != 0:
+                    break
+                yield []
+        except StopIteration:
+            return []
 
-        while True:
-            try:
-                cut = next(iter_cuts)
-            except StopIteration:
-                return []
-            if cut != 0:
-                break
-            yield []
         pos = 0
 
         for segment in segments:
@@ -507,7 +510,7 @@ class Segment(NamedTuple):
                         pos = cut
                 finally:
                     try:
-                        cut = next(iter_cuts)
+                        cut = next_cut()
                     except StopIteration:
                         if split_segments:
                             yield split_segments[:]


### PR DESCRIPTION
Three suggested changes:

- `from __future__ import annotations` might give a slight performance increase as it means type hints don't need to be evaluated.
- Assign `iter(cuts).__next__` to a local function rather than having to look `next` up in the global scope every time (same as in the `itertools` recipe for `roundrobin`).
- Put your whole loop inside a `try/except` clause in lines 477ff, rather than having to do a `try/except` every iteration in the loop. Same as the `itertools` recipe for `iter_except`, and should be just as safe given that you're only catching `StopIteration`.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
