### PR TITLE
Adds the "English readme" link to all README.* files

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich 是一个 Python 库，可以为您在终端中提供富文本和精美格式。

--- a/README.de-ch.md
+++ b/README.de-ch.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich isch ä Python Library för _rich_ Text ond ganz schöni formatiärig im Törminäl

--- a/README.de.md
+++ b/README.de.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich ist eine Python-Bibliothek für _rich_ Text und schöne Formatierung im Terminal.

--- a/README.es.md
+++ b/README.es.md
@@ -6,10 +6,19 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+ • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich es un paquete de Python para texto _enriquecido_ y un hermoso formato en la terminal.
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 La [API Rich](https://rich.readthedocs.io/en/latest/) facilita la adición de color y estilo a la salida del terminal. Rich también puede representar tablas bonitas, barras de progreso, markdown, código fuente resaltado por sintaxis, trazas y más — listo para usar.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich est une bibliothèque Python pour le _rich_ texte et la mise en forme dans le terminal.

--- a/README.hi.md
+++ b/README.hi.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich टर्मिनल में _समृद्ध_ पाठ और सुंदर स्वरूपण के लिए एक Python संग्रह है। 

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Richは、_リッチ_なテキストや美しい書式設定をターミナルで行うためのPythonライブラリです。

--- a/README.kr.md
+++ b/README.kr.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich는 터미널에서 _풍부한(rich)_ 텍스트와 아름다운 서식을 지원하기 위한 파이썬 라이브러리입니다.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich is a Python library for _rich_ text and beautiful formatting in the terminal.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md) • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich é uma biblioteca Python para _rich_ text e formatação de estilos no termial.

--- a/README.sv.md
+++ b/README.sv.md
@@ -6,7 +6,16 @@
 
 ![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
 
-[中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md) • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md) • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md) • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md) • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md) • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md) • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md) • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
+ • [中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
+ • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
+ • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
+ • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
+ • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
+ • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
+ • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
+ • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
+ • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
  • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
 
 Rich är ett Python bibliotek för _rich_ text och vacker formattering i terminalen.


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I've been working on a new translation and found it unnatural not having a link to go back to the English version of the readme, as it was a quick change I decided to propose instead of asking.