### PR TITLE
revert expected test_repr value for py3.10 following upstream

### DIFF
--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -10,16 +10,10 @@ from rich.style import Style
 def test_repr():
     assert repr(Segment("foo")) == "Segment('foo')"
     home = (ControlType.HOME, 0)
-    if sys.version_info >= (3, 10):
-        assert (
-            repr(Segment("foo", None, [home]))
-            == "Segment('foo', None, [(ControlType.HOME, 0)])"
-        )
-    else:
-        assert (
-            repr(Segment("foo", None, [home]))
-            == "Segment('foo', None, [(<ControlType.HOME: 3>, 0)])"
-        )
+    assert (
+        repr(Segment("foo", None, [home]))
+        == "Segment('foo', None, [(<ControlType.HOME: 3>, 0)])"
+    )
 
 
 def test_line():


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

All Enum changes were reverted from Python 3.10 just before rc1.  Revert
the test changes to fix test failures with 3.10.0rc1.