### PR TITLE
Corrected typo in Console Markup docs.

### DIFF
--- a/docs/source/markup.rst
+++ b/docs/source/markup.rst
@@ -80,7 +80,7 @@ Calling ``greet("Will")`` will print a greeting, but if you were to call ``greet
 Emoji
 ~~~~~
 
-If you add an *emoji code* to markup it will be replaced with the equivalent unicode character. An emoji code consists of th name of the emoji surrounded be colons (:). Here's an example::
+If you add an *emoji code* to markup it will be replaced with the equivalent unicode character. An emoji code consists of the name of the emoji surrounded be colons (:). Here's an example::
 
     >>> from rich import print
     >>> print(":warning:")


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Noticed when reading. Missing letter on “the”
