### PR TITLE
Corrected typo in Padding docs.

### DIFF
--- a/docs/source/padding.rst
+++ b/docs/source/padding.rst
@@ -24,4 +24,4 @@ The Padding class can also accept a ``style`` argument which applies a style to 
     test = Padding("Hello", (2, 4), style="on blue", expand=False)
     print(test)
 
-Note that, as with all Rich renderables, you can use Padding any context. For instance, if you want to emphasize an item in a :class:`~rich.table.Table` you could add a Padding object to a row with a padding of 1 and a style of "on red".
+Note that, as with all Rich renderables, you can use Padding in any context. For instance, if you want to emphasize an item in a :class:`~rich.table.Table` you could add a Padding object to a row with a padding of 1 and a style of "on red".


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This I think is the minimum change here, to add the missing word. By this point in the docs, “in any context that accepts a string”, or similar is probably a bit much.
