### PR TITLE
BUG: ensure the global _console object is initialized properly when rich.reconfigure is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+
+- Fixed a bug where calling `rich.reconfigure` within a `pytest_configure` hook would lead to a crash
+
 ## [10.7.0] - 2021-08-05
 
 ### Added

--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -41,6 +41,7 @@ def reconfigure(*args: Any, **kwargs: Any) -> None:
     from rich.console import Console
 
     new_console = Console(*args, **kwargs)
+    _console = get_console()
     _console.__dict__ = new_console.__dict__
 
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

(really not sure how to test this properly)

## Description

fix #1425

