### PR TITLE
Bugfix: Don't print docstring in inspect() if docs is False

### DIFF
--- a/rich/_inspect.py
+++ b/rich/_inspect.py
@@ -149,14 +149,15 @@ class Inspect(JupyterMixin):
                 yield signature
                 yield ""
 
-        _doc = getdoc(obj)
-        if _doc is not None:
-            if not self.help:
-                _doc = _first_paragraph(_doc)
-            doc_text = Text(_reformat_doc(_doc), style="inspect.help")
-            doc_text = highlighter(doc_text)
-            yield doc_text
-            yield ""
+        if self.docs:
+            _doc = getdoc(obj)
+            if _doc is not None:
+                if not self.help:
+                    _doc = _first_paragraph(_doc)
+                doc_text = Text(_reformat_doc(_doc), style="inspect.help")
+                doc_text = highlighter(doc_text)
+                yield doc_text
+                yield ""
 
         if self.value and not (isclass(obj) or callable(obj) or ismodule(obj)):
             yield Panel(


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes: when using `inspect(obj, docs=False)` the docstring is still being printed.
