### PR TITLE
Add stdin support to rich.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added stdin support to `rich.json`
+
 ## [10.9.0] - 2020-08-29
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,4 +15,5 @@ The following people have contributed to the development of Rich:
 - [Kylian Point](https://github.com/p0lux)
 - [Kyle Pollina](https://github.com/kylepollina)
 - [Clément Robert](https://github.com/neutrinoceros)
+- [Tushar Sadhwani](https://github.com/tusharsadhwani)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)

--- a/rich/json.py
+++ b/rich/json.py
@@ -54,6 +54,7 @@ if __name__ == "__main__":
         "path",
         metavar="PATH",
         help="path to file, or - for stdin",
+        nargs='?',
     )
     parser.add_argument(
         "-i",
@@ -69,10 +70,13 @@ if __name__ == "__main__":
 
     console = Console()
     error_console = Console(stderr=True)
-
+        
     try:
-        with open(args.path, "rt") as json_file:
-            json_data = json_file.read()
+        if args.path is None:
+            json_data = sys.stdin.read()
+        else:
+            with open(args.path, "rt") as json_file:
+                json_data = json_file.read()
     except Exception as error:
         error_console.print(f"Unable to read {args.path!r}; {error}")
         sys.exit(-1)

--- a/rich/json.py
+++ b/rich/json.py
@@ -54,7 +54,6 @@ if __name__ == "__main__":
         "path",
         metavar="PATH",
         help="path to file, or - for stdin",
-        nargs="?",
     )
     parser.add_argument(
         "-i",
@@ -72,7 +71,7 @@ if __name__ == "__main__":
     error_console = Console(stderr=True)
 
     try:
-        if args.path is None:
+        if args.path == "-":
             json_data = sys.stdin.read()
         else:
             with open(args.path, "rt") as json_file:

--- a/rich/json.py
+++ b/rich/json.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         "path",
         metavar="PATH",
         help="path to file, or - for stdin",
-        nargs='?',
+        nargs="?",
     )
     parser.add_argument(
         "-i",
@@ -70,7 +70,7 @@ if __name__ == "__main__":
 
     console = Console()
     error_console = Console(stderr=True)
-        
+
     try:
         if args.path is None:
             json_data = sys.stdin.read()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add support for `rich.json` to read input from stdin (eg. pipes) when no file name is provided.
