### PR TITLE
Use builtin html.escape

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from functools import wraps
 from getpass import getpass
+from html import escape
 from inspect import isclass
 from itertools import islice
 from time import monotonic
@@ -2011,10 +2012,6 @@ class Console:
         append = fragments.append
         _theme = theme or DEFAULT_TERMINAL_THEME
         stylesheet = ""
-
-        def escape(text: str) -> str:
-            """Escape html."""
-            return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
         render_code_format = CONSOLE_HTML_FORMAT if code_format is None else code_format
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -395,9 +395,9 @@ def test_export_text():
 
 def test_export_html():
     console = Console(record=True, width=100)
-    console.print("[b]foo [link=https://example.org]Click[/link]")
+    console.print("[b]foo <script> 'test' [link=https://example.org]Click[/link]")
     html = console.export_html()
-    expected = '<!DOCTYPE html>\n<head>\n<meta charset="UTF-8">\n<style>\n.r1 {font-weight: bold}\nbody {\n    color: #000000;\n    background-color: #ffffff;\n}\n</style>\n</head>\n<html>\n<body>\n    <code>\n        <pre style="font-family:Menlo,\'DejaVu Sans Mono\',consolas,\'Courier New\',monospace"><span class="r1">foo </span><a class="r1" href="https://example.org">Click</a>\n</pre>\n    </code>\n</body>\n</html>\n'
+    expected = '<!DOCTYPE html>\n<head>\n<meta charset="UTF-8">\n<style>\n.r1 {font-weight: bold}\n.r2 {color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold}\n.r3 {color: #008000; text-decoration-color: #008000; font-weight: bold}\nbody {\n    color: #000000;\n    background-color: #ffffff;\n}\n</style>\n</head>\n<html>\n<body>\n    <code>\n        <pre style="font-family:Menlo,\'DejaVu Sans Mono\',consolas,\'Courier New\',monospace"><span class="r1">foo &lt;</span><span class="r2">script</span><span class="r1">&gt; </span><span class="r3">&#x27;test&#x27;</span><span class="r1"> </span><a class="r1" href="https://example.org">Click</a>\n</pre>\n    </code>\n</body>\n</html>\n'
     assert html == expected
 
 
@@ -405,7 +405,6 @@ def test_export_html_inline():
     console = Console(record=True, width=100)
     console.print("[b]foo [link=https://example.org]Click[/link]")
     html = console.export_html(inline_styles=True)
-    print(repr(html))
     expected = '<!DOCTYPE html>\n<head>\n<meta charset="UTF-8">\n<style>\n\nbody {\n    color: #000000;\n    background-color: #ffffff;\n}\n</style>\n</head>\n<html>\n<body>\n    <code>\n        <pre style="font-family:Menlo,\'DejaVu Sans Mono\',consolas,\'Courier New\',monospace"><span style="font-weight: bold">foo </span><span style="font-weight: bold"><a href="https://example.org">Click</a></span>\n</pre>\n    </code>\n</body>\n</html>\n'
     assert html == expected
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Replace hand-rolled html escape function with builtin `html.escape`.

Has the added benefit of escaping `"` with `&quot;` and `'` with `&#x27;`.

Also deleted a stray print in the test.