### PR TITLE
Pretty.traverse : patch obj.__getattr__ if exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added stdin support to `rich.json`
 
+### Fixed
+
+- Fixed pretty.traverse, for some edge cases when `__getattr__` forces casting, leading to a exception.
+
 ## [10.9.0] - 2021-08-29
 
 ### Added

--- a/tests/test_pretty_traverse.py
+++ b/tests/test_pretty_traverse.py
@@ -1,0 +1,124 @@
+from rich.pretty import traverse
+
+
+def test_class():
+    """Test if can traverse a class."""
+
+    class Plop:
+        pass
+
+    traverse(Plop)
+
+
+def test_instance():
+    """Test if can traverse a class's instance."""
+
+    class Plop:
+        pass
+
+    traverse(Plop())
+
+
+def test_class_getattr():
+    """Test if can traverse a class with special __getattr__'s casting."""
+
+    class NotCallable:
+        pass
+
+    class Meta(type):
+        def __getattr__(self, name):
+            return NotCallable()
+
+    class Plop(metaclass=Meta):
+        pass
+
+    traverse(Plop)
+
+
+def test_instance_getattr():
+    """Test if can traverse a class's instance with special __getattr__'s casting."""
+
+    class NotCallable:
+        pass
+
+    class Plop:
+        def __getattr__(self, name):
+            return NotCallable()
+
+    traverse(Plop())
+
+
+def test_method():
+    """Test if can traverse a method."""
+
+    def plop():
+        pass
+
+    traverse(plop)
+
+
+def test_integer():
+    """Test if can traverse an integer."""
+    plop = 44
+    traverse(plop)
+
+
+def test_float():
+    """Test if can traverse a float."""
+    plop = 1.618
+    traverse(plop)
+
+
+def test_string():
+    """Test if can traverse a string."""
+    plop = "plop"
+    traverse(plop)
+
+
+def test_list():
+    """Test if can traverse a list."""
+    plop = ["plop", "test"]
+    traverse(plop)
+
+
+def test_tuple():
+    """Test if can traverse a tuple."""
+    plop = ("plop", "test")
+    traverse(plop)
+
+
+def test_set():
+    """Test if can traverse a set."""
+    plop = {"plop", "test"}
+    traverse(plop)
+
+
+def test_dictionary():
+    """Test if can traverse a dictionary."""
+    plop = {"plop": "PLOP", "test": 5}
+    traverse(plop)
+
+
+def test_iterator():
+    """Test if can traverse an iterator."""
+    plop = ["plop", "test"]
+    traverse(iter(plop))
+
+
+def test_generator():
+    """Test if can traverse a generator."""
+    plop = ["plop", "test"]
+    traverse(item for item in plop)
+
+
+def test_builtin_method():
+    """Test if can traverse a built-in method."""
+    plop = bool
+    traverse(plop)
+
+
+def test_module():
+    """Test if can traverse a module."""
+    import rich as plop
+
+    traverse(plop)


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [><"] I accept that @willmcgugan may be pedantic in the code review.

## Description
Some library can return a  `__rich_repr__` which is not callable by doing some stuff in __getattr__. This requires to patch __getattr__'s method to allow __rich_repr__ to act normally.
#1492  