### PR TITLE
Add additional check in __get__ for _Bit class

### DIFF
--- a/rich/style.py
+++ b/rich/style.py
@@ -24,7 +24,7 @@ class _Bit:
 
     def __get__(self, obj: "Style", objtype: Type["Style"]) -> Optional[bool]:
         # If Style object has not been instantiated `obj` will be `None`
-        if obj is None:
+        if obj is None:  # noqa
             return None
 
         if obj._set_attributes & self.bit:

--- a/rich/style.py
+++ b/rich/style.py
@@ -23,6 +23,10 @@ class _Bit:
         self.bit = 1 << bit_no
 
     def __get__(self, obj: "Style", objtype: Type["Style"]) -> Optional[bool]:
+        # If Style object has not been instantiated `obj` will be `None`
+        if obj is None:
+            return None
+
         if obj._set_attributes & self.bit:
             return obj._attributes & self.bit != 0
         return None


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fix a bug when trying to access attributes of uninitialized `Style` class.

Before change:

```python
Python 3.9.1 (v3.9.1:1e5d33e9b9, Dec  7 2020, 12:10:52)
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from rich.style import Style
>>> Style.blink
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/kyle/projects/rich/rich/style.py", line 26, in __get__
    if obj._set_attributes & self.bit:
AttributeError: 'NoneType' object has no attribute '_set_attributes'
```

After change:
```python
Python 3.9.1 (v3.9.1:1e5d33e9b9, Dec  7 2020, 12:10:52)
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from rich.style import Style
>>> Style.blink
>>>
```

Accessing an attribute of an uninstantiated class sends `None` as the first argument to `__get__`. Example:
```python
>>> class Foo:
...     def __get__(self, instance, owner):
...             print("instance: ", instance)
...             print("owner: ", owner)
...
>>> class Bar:
...     foo = Foo()
...
>>> Bar.foo
instance:  None
owner:  <class '__main__.Bar'>
>>>
```

I'm not sure if this behavior is intended or not? I don't know the reasoning behind the design of this `__get__` function. Also I just assumed to return `None`. We could also return `self.bit` instead.