### PR TITLE
Fix swapped defaults in docstring for json printing

### DIFF
--- a/rich/json.py
+++ b/rich/json.py
@@ -10,8 +10,8 @@ class JSON:
 
     Args:
         json (str): JSON encoded data.
-        indent (int, optional): Number of characters to indent by. Defaults to True.
-        highlight (bool, optional): Enable highlighting. Defaults to 2.
+        indent (int, optional): Number of characters to indent by. Defaults to 2.
+        highlight (bool, optional): Enable highlighting. Defaults to True.
     """
 
     def __init__(self, json: str, indent: int = 2, highlight: bool = True) -> None:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [X] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Literally just fix the docstring which says what the defaults are for json printing. For indent and highlighting, they're swapped around.
