### PR TITLE
Remove unused import from the `table_movie.py` example

### DIFF
--- a/examples/table_movie.py
+++ b/examples/table_movie.py
@@ -6,7 +6,6 @@ from rich import box
 from rich.align import Align
 from rich.console import Console
 from rich.live import Live
-from rich.measure import Measurement
 from rich.table import Table
 from rich.text import Text
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Removed the unused import of `from rich.measure import Measurement` from the `examples/table_movie.py`.