### PR TITLE
Correct typing of Iterables and small narrowing

### DIFF
--- a/rich/_loop.py
+++ b/rich/_loop.py
@@ -1,9 +1,9 @@
-from typing import Iterable, Tuple, TypeVar
+from typing import Iterable, Iterator, Tuple, TypeVar
 
 T = TypeVar("T")
 
 
-def loop_first(values: Iterable[T]) -> Iterable[Tuple[bool, T]]:
+def loop_first(values: Iterable[T]) -> Iterator[Tuple[bool, T]]:
     """Iterate and generate a tuple with a flag for first value."""
     iter_values = iter(values)
     try:
@@ -15,7 +15,7 @@ def loop_first(values: Iterable[T]) -> Iterable[Tuple[bool, T]]:
         yield False, value
 
 
-def loop_last(values: Iterable[T]) -> Iterable[Tuple[bool, T]]:
+def loop_last(values: Iterable[T]) -> Iterator[Tuple[bool, T]]:
     """Iterate and generate a tuple with a flag for last value."""
     iter_values = iter(values)
     try:
@@ -28,7 +28,7 @@ def loop_last(values: Iterable[T]) -> Iterable[Tuple[bool, T]]:
     yield True, previous_value
 
 
-def loop_first_last(values: Iterable[T]) -> Iterable[Tuple[bool, bool, T]]:
+def loop_first_last(values: Iterable[T]) -> Iterator[Tuple[bool, bool, T]]:
     """Iterate and generate a tuple with a flag for first and last value."""
     iter_values = iter(values)
     try:

--- a/rich/align.py
+++ b/rich/align.py
@@ -1,6 +1,6 @@
 import sys
 from itertools import chain
-from typing import TYPE_CHECKING, Iterable, Optional
+from typing import TYPE_CHECKING, Iterable, Iterator, Optional
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -151,7 +151,7 @@ class Align(JupyterMixin):
         excess_space = options.max_width - width
         style = console.get_style(self.style) if self.style is not None else None
 
-        def generate_segments() -> Iterable[Segment]:
+        def generate_segments() -> Iterator[Segment]:
             if excess_space <= 0:
                 # Exact fit
                 for line in lines:
@@ -196,7 +196,7 @@ class Align(JupyterMixin):
             else Segment("\n")
         )
 
-        def blank_lines(count: int) -> Iterable[Segment]:
+        def blank_lines(count: int) -> Iterator[Segment]:
             if count > 0:
                 for _ in range(count):
                     yield blank_line
@@ -268,7 +268,7 @@ class VerticalCenter(JupyterMixin):
         bottom_space = height - top_space - len(lines)
         blank_line = Segment(f"{' ' * width}", style)
 
-        def blank_lines(count: int) -> Iterable[Segment]:
+        def blank_lines(count: int) -> Iterator[Segment]:
             for _ in range(count):
                 yield blank_line
                 yield new_line

--- a/rich/ansi.py
+++ b/rich/ansi.py
@@ -1,6 +1,6 @@
 from contextlib import suppress
 import re
-from typing import Iterable, NamedTuple
+from typing import Iterable, Iterator, NamedTuple
 
 from .color import Color
 from .style import Style
@@ -18,7 +18,7 @@ class _AnsiToken(NamedTuple):
     osc: str = ""
 
 
-def _ansi_tokenize(ansi_text: str) -> Iterable[_AnsiToken]:
+def _ansi_tokenize(ansi_text: str) -> Iterator[_AnsiToken]:
     """Tokenize a string in to plain text and ANSI codes.
 
     Args:
@@ -111,7 +111,7 @@ class AnsiDecoder:
     def __init__(self) -> None:
         self.style = Style.null()
 
-    def decode(self, terminal_text: str) -> Iterable[Text]:
+    def decode(self, terminal_text: str) -> Iterator[Text]:
         """Decode ANSI codes in an interable of lines.
 
         Args:

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -15,6 +15,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Set,
@@ -310,7 +311,7 @@ class Node:
     key_separator = ": "
     separator: str = ", "
 
-    def iter_tokens(self) -> Iterable[str]:
+    def iter_tokens(self) -> Iterator[str]:
         """Generate tokens for this node."""
         if self.key_repr:
             yield self.key_repr
@@ -405,7 +406,7 @@ class _Line:
         assert self.node is not None
         return self.node.check_length(start_length, max_length)
 
-    def expand(self, indent_size: int) -> Iterable["_Line"]:
+    def expand(self, indent_size: int) -> Iterator["_Line"]:
         """Expand this line by adding children on their own line."""
         node = self.node
         assert node is not None
@@ -489,7 +490,9 @@ def traverse(
         py_version = (sys.version_info.major, sys.version_info.minor)
         children: List[Node]
 
-        def iter_rich_args(rich_args: Any) -> Iterable[Union[Any, Tuple[str, Any]]]:
+        def iter_rich_args(
+            rich_args: Iterable[Any],
+        ) -> Iterator[Union[Any, Tuple[str, Any]]]:
             for arg in rich_args:
                 if isinstance(arg, tuple):
                     if len(arg) == 3:
@@ -574,7 +577,7 @@ def traverse(
                     last=root,
                 )
 
-                def iter_attrs() -> Iterable[
+                def iter_attrs() -> Iterator[
                     Tuple[str, Any, Optional[Callable[[Any], str]]]
                 ]:
                     """Iterate over attr fields and values."""

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -3,7 +3,18 @@ import platform
 from rich.containers import Lines
 import textwrap
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 from pygments.lexers import get_lexer_by_name, guess_lexer_for_filename
 from pygments.style import Style as PygmentsStyle
@@ -388,14 +399,14 @@ class Syntax(JupyterMixin):
                 # This speeds up further operations as there are less spans to process
                 line_start, line_end = line_range
 
-                def line_tokenize() -> Iterable[Tuple[Any, str]]:
+                def line_tokenize() -> Iterator[Tuple[Any, str]]:
                     """Split tokens to one per line."""
                     for token_type, token in lexer.get_tokens(code):
                         while token:
                             line_token, new_line, token = token.partition("\n")
                             yield token_type, line_token + new_line
 
-                def tokens_to_spans() -> Iterable[Tuple[str, Optional[Style]]]:
+                def tokens_to_spans() -> Iterator[Tuple[str, Optional[Style]]]:
                     """Convert tokens to spans."""
                     tokens = iter(line_tokenize())
                     line_no = 0


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

A lot of the Iterators in the code were typed as Iterable when they were more appropriately typed as an Iterator (i.e they support next). I also narrowed a type a bit.

There were a lot of instances in the code where usage of `Any` can or should be replaced with `object`, but I'm not sure if you have strong opinions on this. If you're open to all instances of more narrowly typing the library I may work on this in my free time.
