### PR TITLE
fix: Dataclass pretty repr can contain a trailing separator and whitespace

### DIFF
--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -647,11 +647,11 @@ def traverse(
 
             repr_fields = (field for field in fields(obj) if field.repr)
             for last, field in loop_last(repr_fields):
-                    child_node = _traverse(getattr(obj, field.name))
-                    child_node.key_repr = field.name
-                    child_node.last = last
-                    child_node.key_separator = "="
-                    append(child_node)
+                child_node = _traverse(getattr(obj, field.name))
+                child_node.key_repr = field.name
+                child_node.last = last
+                child_node.key_separator = "="
+                append(child_node)
 
             pop_visited(obj_id)
 

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -645,8 +645,8 @@ def traverse(
                 last=root,
             )
 
-            for last, field in loop_last(fields(obj)):
-                if field.repr:
+            repr_fields = (field for field in fields(obj) if field.repr)
+            for last, field in loop_last(repr_fields):
                     child_node = _traverse(getattr(obj, field.name))
                     child_node.key_repr = field.name
                     child_node.last = last

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -67,6 +67,7 @@ class ExampleDataclass:
     bar: str
     ignore: int = field(repr=False)
     baz: List[str] = field(default_factory=list)
+    _ignore: int = field(init=False, repr=False)
 
 
 def test_pretty_dataclass():


### PR DESCRIPTION
Dataclass pretty repr can contain a trailing separator and whitespace

Fixed pretty_repr() for dataclass fields with repr=False.
Fixed corresponding test.

## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [X] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description
Issue: https://github.com/willmcgugan/rich/issues/1599

Changed logic for looping over dataclass fields so now there will always be a child_node marked as last, even if the final field has its repr disabled.

Filter the fields by field.repr is True before passing to loop_last, instead of afterwards.

Modified the corresponding test so the current undesireable behavior would be caught.