### PR TITLE
feat(bars):  pause and resume methods to progress bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.12.1] - unreleased
 
+- Added pause and resume methods to progress bars
+
 ### Fixed
 
 - Fixed an edge case bug when console module try to detect if they are in a tty at the end of a pytest run

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@ The following people have contributed to the development of Rich:
 - [Clément Robert](https://github.com/neutrinoceros)
 - [Tushar Sadhwani](https://github.com/tusharsadhwani)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
+- [Andrea Maugeri](https://github.com/v0lp3)

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -33,7 +33,6 @@ from .spinner import Spinner
 from .style import StyleType
 from .table import Column, Table
 from .text import Text, TextType
-from rich import progress_bar
 
 TaskID = NewType("TaskID", int)
 
@@ -1042,7 +1041,7 @@ if __name__ == "__main__":  # pragma: no coverage
 
         task1 = progress.add_task("[red]Downloading", total=1000)
         task2 = progress.add_task("[green]Processing", total=1000)
-        # task3 = progress.add_task("[yellow]Thinking", total=1000, start=False)
+        task3 = progress.add_task("[yellow]Thinking", total=1000, start=False)
 
         test = 0
 
@@ -1058,5 +1057,5 @@ if __name__ == "__main__":  # pragma: no coverage
 
             test += 1
             time.sleep(0.01)
-            # if random.randint(0, 100) < 1:
-            #     progress.log(next(examples))
+            if random.randint(0, 100) < 1:
+                progress.log(next(examples))

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -802,13 +802,13 @@ class Progress(JupyterMixin):
         if refresh:
             self.refresh()
 
-    def pause(self, task_id: TaskID):
+    def pause(self, task_id: TaskID) -> None:
         with self._lock:
             task = self._tasks[task_id]
             task._progress.clear()
             task.paused = True
 
-    def resume(self, task_id: TaskID):
+    def resume(self, task_id: TaskID) -> None:
         with self._lock:
             task = self._tasks[task_id]
             task.paused = False
@@ -1042,13 +1042,13 @@ if __name__ == "__main__":  # pragma: no coverage
 
         task1 = progress.add_task("[red]Downloading", total=1000)
         task2 = progress.add_task("[green]Processing", total=1000)
-        task3 = progress.add_task("[yellow]Thinking", total=1000, start=False)
+        # task3 = progress.add_task("[yellow]Thinking", total=1000, start=False)
 
         test = 0
 
         while not progress.finished:
-            progress.update(task1, advance=0.5)
-            progress.update(task2, advance=0.3)
+            progress.update(task1, advance=1)
+            progress.update(task2, advance=1)
 
             if test == 200:
                 progress.pause(task1)
@@ -1058,5 +1058,5 @@ if __name__ == "__main__":  # pragma: no coverage
 
             test += 1
             time.sleep(0.01)
-            if random.randint(0, 100) < 1:
-                progress.log(next(examples))
+            # if random.randint(0, 100) < 1:
+            #     progress.log(next(examples))

--- a/rich/progress_bar.py
+++ b/rich/progress_bar.py
@@ -51,8 +51,8 @@ class ProgressBar(JupyterMixin):
         self.finished_style = finished_style
         self.pulse_style = pulse_style
         self.animation_time = animation_time
-        self.paused = False
-        self.paused_time = 0
+        self.paused: bool = False
+        self.paused_time: float = 0
         self._pulse_segments: Optional[List[Segment]] = None
 
     def __repr__(self) -> str:
@@ -127,10 +127,10 @@ class ProgressBar(JupyterMixin):
 
         self.total = total if total is not None else self.total
 
-    def pause(self):
+    def pause(self) -> None:
         self.paused = True
 
-    def resume(self):
+    def resume(self) -> None:
         self.paused = False
 
     def _render_pulse(

--- a/rich/progress_bar.py
+++ b/rich/progress_bar.py
@@ -51,7 +51,8 @@ class ProgressBar(JupyterMixin):
         self.finished_style = finished_style
         self.pulse_style = pulse_style
         self.animation_time = animation_time
-
+        self.paused = False
+        self.paused_time = 0
         self._pulse_segments: Optional[List[Segment]] = None
 
     def __repr__(self) -> str:
@@ -118,8 +119,19 @@ class ProgressBar(JupyterMixin):
             completed (float): Number of steps completed.
             total (float, optional): Total number of steps, or ``None`` to not change. Defaults to None.
         """
-        self.completed = completed
+        if not self.paused:
+            self.completed = completed - self.paused_time
+
+        else:
+            self.paused_time = completed - self.completed
+
         self.total = total if total is not None else self.total
+
+    def pause(self):
+        self.paused = True
+
+    def resume(self):
+        self.paused = False
 
     def _render_pulse(
         self, console: Console, width: int, ascii: bool = False
@@ -207,7 +219,13 @@ if __name__ == "__main__":  # pragma: no cover
     import time
 
     console.show_cursor(False)
-    for n in range(0, 101, 1):
+    for n in range(0, 121, 1):
+        if n == 80:
+            bar.pause()
+
+        if n == 100:
+            bar.resume()
+
         bar.update(n)
         console.print(bar)
         console.file.write("\r")

--- a/rich/progress_bar.py
+++ b/rich/progress_bar.py
@@ -52,7 +52,7 @@ class ProgressBar(JupyterMixin):
         self.pulse_style = pulse_style
         self.animation_time = animation_time
         self.paused: bool = False
-        self.paused_time: float = 0
+        self.paused_delta: float = 0
         self._pulse_segments: Optional[List[Segment]] = None
 
     def __repr__(self) -> str:
@@ -120,10 +120,10 @@ class ProgressBar(JupyterMixin):
             total (float, optional): Total number of steps, or ``None`` to not change. Defaults to None.
         """
         if not self.paused:
-            self.completed = completed - self.paused_time
+            self.completed = completed - self.paused_delta
 
         else:
-            self.paused_time = completed - self.completed
+            self.paused_delta = completed - self.completed
 
         self.total = total if total is not None else self.total
 

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -91,12 +91,14 @@ def test_get_pulse_segments():
     ]
     assert segments == expected
 
+
 def test_pause():
     bar = ProgressBar(width=50, total=100)
     bar.update(20)
     bar.pause()
     bar.update(21)
-    assert bar.completed == 20    
+    assert bar.completed == 20
+
 
 def test_resume():
     bar = ProgressBar(width=50, total=100)
@@ -107,10 +109,12 @@ def test_resume():
     bar.update(23)
     bar.resume()
     bar.update(24)
-    assert bar.completed == 21    
+    assert bar.completed == 21
+
 
 def test_resume():
     """todo"""
+
 
 if __name__ == "__main__":
     bar = ProgressBar(completed=11, width=50)

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -91,6 +91,26 @@ def test_get_pulse_segments():
     ]
     assert segments == expected
 
+def test_pause():
+    bar = ProgressBar(width=50, total=100)
+    bar.update(20)
+    bar.pause()
+    bar.update(21)
+    assert bar.completed == 20    
+
+def test_resume():
+    bar = ProgressBar(width=50, total=100)
+    bar.update(20)
+    bar.pause()
+    bar.update(21)
+    bar.update(22)
+    bar.update(23)
+    bar.resume()
+    bar.update(24)
+    assert bar.completed == 21    
+
+def test_resume():
+    """todo"""
 
 if __name__ == "__main__":
     bar = ProgressBar(completed=11, width=50)

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -112,10 +112,6 @@ def test_resume():
     assert bar.completed == 21
 
 
-def test_resume():
-    """todo"""
-
-
 if __name__ == "__main__":
     bar = ProgressBar(completed=11, width=50)
     bar_render = render(bar)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -406,6 +406,32 @@ def test_reset() -> None:
     assert not task._progress
 
 
+def test_pause() -> None:
+    progress = Progress()
+    task_id = progress.add_task("foo")
+    progress.update(task_id, advance=1)
+    progress.update(task_id, advance=1)
+    task = progress.tasks[task_id]
+    progress.pause(task_id)
+    progress.update(task_id, advance=1)
+    progress.update(task_id, advance=7)
+    assert task.completed == 2
+
+
+def test_resume() -> None:
+    progress = Progress()
+    task_id = progress.add_task("foo")
+    progress.update(task_id, advance=1)
+    progress.update(task_id, advance=1)
+    task = progress.tasks[task_id]
+    progress.pause(task_id)
+    progress.update(task_id, advance=1)
+    progress.update(task_id, advance=7)
+    progress.resume(task_id)
+    progress.update(task_id, advance=5)
+    assert task.completed == 7
+
+
 def test_progress_max_refresh() -> None:
     """Test max_refresh argument."""
     time = 0.0
@@ -439,7 +465,7 @@ def test_progress_max_refresh() -> None:
             progress.update(task_id, description=f"tick {tick}")
             progress.refresh()
     result = console.end_capture()
-    print(repr(result))
+    # print(repr(result))
     assert (
         result
         == "\x1b[?25l\r\x1b[2Kstart\r\x1b[2Kstart\r\x1b[2Ktick 1\r\x1b[2Ktick 1\r\x1b[2Ktick 3\r\x1b[2Ktick 3\r\x1b[2Ktick 5\r\x1b[2Ktick 5\n\x1b[?25h"


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I added code for pause and resume progress bars.
Actually _progress.py_ and _progress_bar.py_ pause and resume methods are implemented in different way because Progress use ProgressBar indirectly (render the progress bar as new instance every time):
- *progress.py*: Set a flag in Task object, so the update method not add the advance to `task.completed`.
- *progres_bar.py*: Set a flag `paused` in ProgressBar class and track advance in `paused_delta`. 

Briefly, i couldn't reuse the methods pause and resume of ProgressBar into Progress, but I think that the result is enough good.
 
![progress](https://user-images.githubusercontent.com/20267645/137603229-46558fde-eb88-4b76-80e1-887f0a92e06a.gif)

![progress bar](https://user-images.githubusercontent.com/20267645/137603486-b165361a-63ef-4a24-9ce7-8052a2cf1fd5.gif)

close #1535