### PR TITLE
Remove extra space in Theme example

### DIFF
--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -115,7 +115,7 @@ To use a style theme, construct a :class:`~rich.theme.Theme` instance and pass i
     from rich.console import Console
     from rich.theme import Theme
     custom_theme = Theme({
-        "info" : "dim cyan",
+        "info": "dim cyan",
         "warning": "magenta",
         "danger": "bold red"
     })


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Remove extra space in `Theme` example.
