### PR TITLE
Have logger link to proper file line.

### DIFF
--- a/rich/_log_render.py
+++ b/rich/_log_render.py
@@ -75,7 +75,11 @@ class LogRender:
                 path, style=f"link file://{link_path}" if link_path else ""
             )
             if line_no:
-                path_text.append(f":{line_no}")
+                path_text.append(":")
+                path_text.append(
+                    f"{line_no}",
+                    style=f"link file://{link_path}#{line_no}" if link_path else "",
+                )
             row.append(path_text)
 
         output.add_row(*row)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -6,8 +6,7 @@ import re
 
 from rich.console import Console
 
-
-re_link_ids = re.compile(r"id=[\d\.\-]*?;.*?\x1b")
+re_link_ids = re.compile(r"id=((\d+);(file:///(\w+\/)+(\w+\.py)(#\d+)?))\x1b")
 
 
 def replace_link_ids(render: str) -> str:
@@ -15,7 +14,7 @@ def replace_link_ids(render: str) -> str:
     reproducible tests.
 
     """
-    return re_link_ids.sub("id=0;foo\x1b", render)
+    return re_link_ids.sub("id=0;file:///path/to/source.py#00\x1b", render)
 
 
 test_data = [1, 2, 3]
@@ -33,13 +32,11 @@ def render_log():
     console.log()
     console.log("Hello from", console, "!")
     console.log(test_data, log_locals=True)
-    return replace_link_ids(console.file.getvalue())
+    return replace_link_ids(console.file.getvalue()).replace('test_log.py','source.py')
 
 
 def test_log():
-    expected = replace_link_ids(
-        "\x1b[2;36m[TIME]\x1b[0m\x1b[2;36m \x1b[0m                                                           \x1b]8;id=0;foo\x1b\\\x1b[2mtest_log.py\x1b[0m\x1b]8;;\x1b\\\x1b[2m:33\x1b[0m\n\x1b[2;36m      \x1b[0m\x1b[2;36m \x1b[0mHello from \x1b[1m<\x1b[0m\x1b[1;95mconsole\x1b[0m\x1b[39m \x1b[0m\x1b[33mwidth\x1b[0m\x1b[39m=\x1b[0m\x1b[1;36m80\x1b[0m\x1b[39m ColorSystem.TRUECOLOR\x1b[0m\x1b[1m>\x1b[0m !      \x1b]8;id=0;foo\x1b\\\x1b[2mtest_log.py\x1b[0m\x1b]8;;\x1b\\\x1b[2m:34\x1b[0m\n\x1b[2;36m      \x1b[0m\x1b[2;36m \x1b[0m\x1b[1m[\x1b[0m\x1b[1;36m1\x1b[0m, \x1b[1;36m2\x1b[0m, \x1b[1;36m3\x1b[0m\x1b[1m]\x1b[0m                                                  \x1b]8;id=0;foo\x1b\\\x1b[2mtest_log.py\x1b[0m\x1b]8;;\x1b\\\x1b[2m:35\x1b[0m\n       \x1b[34m╭─\x1b[0m\x1b[34m───────────────────── \x1b[0m\x1b[3;34mlocals\x1b[0m\x1b[34m ─────────────────────\x1b[0m\x1b[34m─╮\x1b[0m                   \n       \x1b[34m│\x1b[0m \x1b[3;33mconsole\x1b[0m\x1b[31m =\x1b[0m \x1b[1m<\x1b[0m\x1b[1;95mconsole\x1b[0m\x1b[39m \x1b[0m\x1b[33mwidth\x1b[0m\x1b[39m=\x1b[0m\x1b[1;36m80\x1b[0m\x1b[39m ColorSystem.TRUECOLOR\x1b[0m\x1b[1m>\x1b[0m \x1b[34m│\x1b[0m                   \n       \x1b[34m╰────────────────────────────────────────────────────╯\x1b[0m                   \n"
-    )
+    expected = replace_link_ids('\x1b[2;36m[TIME]\x1b[0m\x1b[2;36m \x1b[0m                                                           \x1b]8;id=0;file:///path/to/foo.py#00\x1b\\\x1b[2msource.py\x1b[0m\x1b]8;;\x1b\\\x1b[2m:\x1b[0m\x1b]8;id=0;file:///path/to/foo.py#00\x1b\\\x1b[2m32\x1b[0m\x1b]8;;\x1b\\\n\x1b[2;36m      \x1b[0m\x1b[2;36m \x1b[0mHello from \x1b[1m<\x1b[0m\x1b[1;95mconsole\x1b[0m\x1b[39m \x1b[0m\x1b[33mwidth\x1b[0m\x1b[39m=\x1b[0m\x1b[1;36m80\x1b[0m\x1b[39m ColorSystem.TRUECOLOR\x1b[0m\x1b[1m>\x1b[0m !      \x1b]8;id=0;file:///path/to/foo.py#00\x1b\\\x1b[2msource.py\x1b[0m\x1b]8;;\x1b\\\x1b[2m:\x1b[0m\x1b]8;id=0;file:///path/to/foo.py#00\x1b\\\x1b[2m33\x1b[0m\x1b]8;;\x1b\\\n\x1b[2;36m      \x1b[0m\x1b[2;36m \x1b[0m\x1b[1m[\x1b[0m\x1b[1;36m1\x1b[0m, \x1b[1;36m2\x1b[0m, \x1b[1;36m3\x1b[0m\x1b[1m]\x1b[0m                                                  \x1b]8;id=0;file:///path/to/foo.py#00\x1b\\\x1b[2msource.py\x1b[0m\x1b]8;;\x1b\\\x1b[2m:\x1b[0m\x1b]8;id=0;file:///path/to/foo.py#00\x1b\\\x1b[2m34\x1b[0m\x1b]8;;\x1b\\\n       \x1b[34m╭─\x1b[0m\x1b[34m───────────────────── \x1b[0m\x1b[3;34mlocals\x1b[0m\x1b[34m ─────────────────────\x1b[0m\x1b[34m─╮\x1b[0m                   \n       \x1b[34m│\x1b[0m \x1b[3;33mconsole\x1b[0m\x1b[31m =\x1b[0m \x1b[1m<\x1b[0m\x1b[1;95mconsole\x1b[0m\x1b[39m \x1b[0m\x1b[33mwidth\x1b[0m\x1b[39m=\x1b[0m\x1b[1;36m80\x1b[0m\x1b[39m ColorSystem.TRUECOLOR\x1b[0m\x1b[1m>\x1b[0m \x1b[34m│\x1b[0m                   \n       \x1b[34m╰────────────────────────────────────────────────────╯\x1b[0m                   \n')
     rendered = render_log()
     print(repr(rendered))
     assert rendered == expected


### PR DESCRIPTION
Some terminal emulators like iterm2, support anchoring to the line
number:

https://iterm2.com/documentation-one-page.html see Anchor (OSC 8)
section:

     Note: in iTerm2 version 3.4 and later, if the URL has the file scheme and
     a # fragment is present then the semantic history rules will apply
     for opening the file. It may optionally include a line number, like
     file:///tmp/file.txt#123 or line number and column number like
     file:///tmp/file.txt#123:45

This update the logic in the logger so that the line number links the
the corresponding file on the same line.

As I'm not sure whether all terminals support that, I let the  clik on
the file name point to the file itself w/o line numbers.

And for discoverability and user friendliness the colon itself is
unstyled so that it's easier to discover that click on the  filename and
line number are two different targets.

## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

I'm not sure it is worth documenting as it is a minor change, and not sure for tests, as it's mostly external software interaction.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

