### PR TITLE
Add rich-markdown CLI script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ classifiers = [
 ]
 include = ["rich/py.typed"]
 
+[tool.poetry.scripts]
+rich-markdown = "rich.markdown:main"
 
 [tool.poetry.dependencies]
 python = "^3.6.2"

--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -529,8 +529,7 @@ class Markdown(JupyterMixin):
                     new_line = element.new_line
 
 
-if __name__ == "__main__":  # pragma: no cover
-
+def main():
     import argparse
     import sys
 
@@ -622,3 +621,7 @@ if __name__ == "__main__":  # pragma: no cover
     else:
         console = Console(force_terminal=args.force_color, width=args.width)
         console.print(markdown)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

- Add `rich.markdown` as a CLI, enabling e.g. the command `rich-markdown README.md` from a pipx-installation of rich

## Background

Hi @willmcgugan 👋 😃 , I was trying to figure out how I could have the excellent `rich.markdown` command readily available in my system, for when I want to skim through a markdown file in my terminal. My goto solution for these things are usually to pipx-install the thing but I noticed this wasn't possible with rich - and that it has no CLI scripts registered in the package spec (`pyproject.toml`).

I have no idea if you think this is a good idea or not, but I figured I'd at least share with you what I did locally on my machine. Feel free to put this PR to rest if you have other plans 👍 

But in case you think this idea is worth exploring, I can try to help finalize this change.

Usage:

```bash
# step 1, install
$ pipx install git+https://github.com/fredrikaverpil/rich.git@markdown-cli
  installed package rich 10.12.0, Python 3.10.0
  These apps are now globally available
    - rich-markdown
done! ✨ 🌟 ✨

# step 2, profit
$ rich-markdown README.md
```