### PR TITLE
Set soft_wrap in console.print json  to prevent truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue with TERM env vars that have more than one hyphen https://github.com/willmcgugan/rich/issues/1640
 - Fixed missing new line after progress bar when terminal is not interactive https://github.com/willmcgugan/rich/issues/1606
 - Fixed exception in IPython when disabling pprint with %pprint https://github.com/willmcgugan/rich/issues/1646
+- Fixed issue where values longer than the console width produced invalid JSON https://github.com/willmcgugan/rich/issues/1653
 
 ## [10.12.0] - 2021-10-06
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ The following people have contributed to the development of Rich:
 
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Pete Davison](https://github.com/pd93)
+- [James Estevez](https://github.com/jstvz)
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Finn Hughes](https://github.com/finnhughes)
 - [Josh Karpel](https://github.com/JoshKarpel)

--- a/rich/console.py
+++ b/rich/console.py
@@ -1679,7 +1679,7 @@ class Console:
                 default=default,
                 sort_keys=sort_keys,
             )
-        self.print(json_renderable)
+        self.print(json_renderable, soft_wrap=True)
 
     def update_screen(
         self,

--- a/tests/test_rich_print.py
+++ b/tests/test_rich_print.py
@@ -1,4 +1,5 @@
 import io
+import json
 
 import rich
 from rich.console import Console
@@ -36,6 +37,27 @@ def test_rich_print_json():
     print(repr(result))
     expected = '[\n    false,\n    true,\n    null,\n    "foo"\n]\n'
     assert result == expected
+
+
+def test_rich_print_json_round_trip():
+    data = ["x" * 100, 2e128]
+    console = rich.get_console()
+    with console.capture() as capture:
+        rich.print_json(data=data, indent=4)
+    result = capture.get()
+    print(repr(result))
+    result_data = json.loads(result)
+    assert result_data == data
+
+
+def test_rich_print_json_no_truncation():
+    console = rich.get_console()
+    with console.capture() as capture:
+        rich.print_json(f'["{"x" * 100}", {int(2e128)}]', indent=4)
+    result = capture.get()
+    print(repr(result))
+    assert ("x" * 100) in result
+    assert str(int(2e128)) in result
 
 
 def test_rich_print_X():


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [X] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review. (😏 )

## Description
This PR adds `soft_wrap=True` to `print_json` to prevent the truncation of values longer than the width of the console.

- Fixes #1653 