### PR TITLE
special case for Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Allowed `__rich__` to work recursively
+- Allowed Text classes to work with sep in print https://github.com/willmcgugan/rich/issues/1689
 
 ## [10.13.0] - 2021-11-07
 

--- a/rich/console.py
+++ b/rich/console.py
@@ -1448,6 +1448,8 @@ class Console:
                         renderable, emoji=emoji, markup=markup, highlighter=_highlighter
                     )
                 )
+            elif isinstance(renderable, Text):
+                append_text(renderable)
             elif isinstance(renderable, ConsoleRenderable):
                 check_text()
                 append(renderable)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -117,6 +117,24 @@ def test_print():
     assert console.file.getvalue() == "foo\n"
 
 
+def test_print_multiple():
+    console = Console(file=io.StringIO(), color_system="truecolor")
+    console.print("foo", "bar")
+    assert console.file.getvalue() == "foo bar\n"
+
+
+def test_print_text():
+    console = Console(file=io.StringIO(), color_system="truecolor")
+    console.print(Text("foo", style="bold"))
+    assert console.file.getvalue() == "\x1B[1mfoo\x1B[0m\n"
+
+
+def test_print_text_multiple():
+    console = Console(file=io.StringIO(), color_system="truecolor")
+    console.print(Text("foo", style="bold"), Text("bar"), "baz")
+    assert console.file.getvalue() == "\x1B[1mfoo\x1B[0m bar baz\n"
+
+
 def test_print_json():
     console = Console(file=io.StringIO(), color_system="truecolor")
     console.print_json('[false, true, null, "foo"]', indent=4)


### PR DESCRIPTION
Special case for Text in print to allow use of sep. Fixes https://github.com/willmcgugan/rich/issues/1689