### PR TITLE
Improve formatting of live command

### DIFF
--- a/docs/source/live.rst
+++ b/docs/source/live.rst
@@ -5,7 +5,7 @@ Live Display
 
 Progress bars and status indicators use a *live* display to animate parts of the terminal. You can build custom live displays with the :class:`~rich.live.Live` class. 
 
-For a demonstration of a live display, run the following command:
+For a demonstration of a live display, run the following command::
 
     python -m rich.live
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Improve the formatting by monospacing the following command:

<img width="762" alt="Screen Shot 2021-11-16 at 11 10 08 AM" src="https://user-images.githubusercontent.com/10340167/142022228-165eecb5-ca76-4edf-b833-05b60ae9e676.png">

