### PR TITLE
Add support for showing threads with RichHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added file protocol to URL highlighter https://github.com/willmcgugan/rich/issues/1681
 - Added rich.protocol.rich_cast
+- Added show_thread to RichHandler to enable showing thread names in logs
 
 ### Changed
 

--- a/rich/_log_render.py
+++ b/rich/_log_render.py
@@ -20,6 +20,8 @@ class LogRender:
         time_format: Union[str, FormatTimeCallable] = "[%x %X]",
         omit_repeated_times: bool = True,
         level_width: Optional[int] = 8,
+        show_thread: bool = False,
+        thread_width: Optional[int] = 10,
     ) -> None:
         self.show_time = show_time
         self.show_level = show_level
@@ -28,6 +30,8 @@ class LogRender:
         self.omit_repeated_times = omit_repeated_times
         self.level_width = level_width
         self._last_time: Optional[Text] = None
+        self.show_thread = show_thread
+        self.thread_width = thread_width
 
     def __call__(
         self,
@@ -39,6 +43,7 @@ class LogRender:
         path: Optional[str] = None,
         line_no: Optional[int] = None,
         link_path: Optional[str] = None,
+        thread_name: Optional[str] = None,
     ) -> "Table":
         from .containers import Renderables
         from .table import Table
@@ -47,6 +52,8 @@ class LogRender:
         output.expand = True
         if self.show_time:
             output.add_column(style="log.time")
+        if self.show_thread:
+            output.add_column(style="log.thread_name", width=self.thread_width)
         if self.show_level:
             output.add_column(style="log.level", width=self.level_width)
         output.add_column(ratio=1, style="log.message", overflow="fold")
@@ -65,6 +72,8 @@ class LogRender:
             else:
                 row.append(log_time_display)
                 self._last_time = log_time_display
+        if self.show_thread:
+            row.append(thread_name)
         if self.show_level:
             row.append(level)
 

--- a/rich/default_styles.py
+++ b/rich/default_styles.py
@@ -60,6 +60,7 @@ DEFAULT_STYLES: Dict[str, Style] = {
     "log.time": Style(color="cyan", dim=True),
     "log.message": Style.null(),
     "log.path": Style(dim=True),
+    "log.thread_name": Style(color="yellow"),
     "repr.ellipsis": Style(color="yellow"),
     "repr.indent": Style(color="green", dim=True),
     "repr.error": Style(color="red", bold=True),

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -28,6 +28,8 @@ class RichHandler(Handler):
         omit_repeated_times (bool, optional): Omit repetition of the same time. Defaults to True.
         show_level (bool, optional): Show a column for the level. Defaults to True.
         show_path (bool, optional): Show the path to the original log call. Defaults to True.
+        show_thread (bool, optional): Show the name of the thread in log entry. Defaults to False.
+        thread_width (int, optional): The number of characters to show for thread name. Defaults to 10.
         enable_link_path (bool, optional): Enable terminal link of path column to file. Defaults to True.
         highlighter (Highlighter, optional): Highlighter to style log messages, or None to use ReprHighlighter. Defaults to None.
         markup (bool, optional): Enable console markup in log messages. Defaults to False.
@@ -64,6 +66,8 @@ class RichHandler(Handler):
         omit_repeated_times: bool = True,
         show_level: bool = True,
         show_path: bool = True,
+        show_thread: bool = False,
+        thread_width: Optional[int] = 10,
         enable_link_path: bool = True,
         highlighter: Optional[Highlighter] = None,
         markup: bool = False,
@@ -87,6 +91,8 @@ class RichHandler(Handler):
             time_format=log_time_format,
             omit_repeated_times=omit_repeated_times,
             level_width=None,
+            show_thread=show_thread,
+            thread_width=thread_width,
         )
         self.enable_link_path = enable_link_path
         self.markup = markup
@@ -195,6 +201,7 @@ class RichHandler(Handler):
         level = self.get_level_text(record)
         time_format = None if self.formatter is None else self.formatter.datefmt
         log_time = datetime.fromtimestamp(record.created)
+        thread_name = record.threadName
 
         log_renderable = self._log_render(
             self.console,
@@ -205,6 +212,7 @@ class RichHandler(Handler):
             path=path,
             line_no=record.lineno,
             link_path=record.pathname if self.enable_link_path else None,
+            thread_name=thread_name,
         )
         return log_renderable
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -122,6 +122,56 @@ def test_stderr_and_stdout_are_none(monkeypatch):
     assert "message" in actual_record.msg
 
 
+def test_thread_in_message():
+    console = Console(
+        file=io.StringIO(),
+        force_terminal=True,
+        width=140,
+        color_system=None,
+        _environ={},
+    )
+    handler_with_threads = RichHandler(
+        console=console, enable_link_path=False, show_thread=True
+    )
+    formatter = logging.Formatter("FORMATTER %(message)s %(asctime)s")
+    handler_with_threads.setFormatter(formatter)
+    log.addHandler(handler_with_threads)
+    log.setLevel(logging.DEBUG)
+    log.debug("foo")
+
+    render = handler_with_threads.console.file.getvalue()
+    print(f"RENDER = '{render}'")
+    log.setLevel(logging.NOTSET)
+
+    assert "MainThread DEBUG" in render
+    assert "FORMATTER foo" in render
+
+
+def test_thread_in_message_thread_width():
+    console = Console(
+        file=io.StringIO(),
+        force_terminal=True,
+        width=140,
+        color_system=None,
+        _environ={},
+    )
+    handler_with_threads = RichHandler(
+        console=console, enable_link_path=False, show_thread=True,
+        thread_width=6
+    )
+    formatter = logging.Formatter("FORMATTER %(message)s %(asctime)s")
+    handler_with_threads.setFormatter(formatter)
+    log.addHandler(handler_with_threads)
+    log.setLevel(logging.DEBUG)
+    log.debug("foo")
+
+    render = handler_with_threads.console.file.getvalue()
+    print(f"RENDER = '{render}'")
+    log.setLevel(logging.NOTSET)
+
+    assert "MainT… DEBUG" in render
+
+
 if __name__ == "__main__":
     render = make_log()
     print(render)


### PR DESCRIPTION
This patch adds the ability to optionally show the thread name
with the RichHandler logger.   This is quite useful for python
applications that have multiple threads and trying to make sense
of the log output.

The thread name is colorized to a color which is created from
a simple hash of the thread name itself.  So a thread name of 'Main'
will always have the same color, but another thread say "socket"
will have a different color.

## Type of changes

- [ ] Bug fix
- [X] New feature
- [X] Documentation / docstrings
- [X] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
