### PR TITLE
Fix failing codespell test

### DIFF
--- a/rich/cells.py
+++ b/rich/cells.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 from ._cell_widths import CELL_WIDTHS
 from ._lru_cache import LRUCache
 
-# Regex to match sequece of the most common character ranges
+# Regex to match sequence of the most common character ranges
 _is_single_cell_widths = re.compile("^[\u0020-\u006f\u00a0\u02ff\u0370-\u0482]*$").match
 
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Change the spelling of sequece to sequence to fix the failing codespell test.
