### PR TITLE
Per message log highlighting

### DIFF
--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -16,9 +16,13 @@ Here's an example of how to set up a rich logger::
     log = logging.getLogger("rich")
     log.info("Hello, World!")
 
-Rich logs won't render :ref:`console_markup` in logging by default as most libraries won't be aware of the need to escape literal square brackets, but you can enable it by setting ``markup=True`` on the handler. Alternatively you can enable it per log message by supplying the ``extra`` argument as follows::  
+Rich logs won't render :ref:`console_markup` in logging by default as most libraries won't be aware of the need to escape literal square brackets, but you can enable it by setting ``markup=True`` on the handler. Alternatively you can enable it per log message by supplying the ``extra`` argument as follows::
 
     log.error("[bold red blink]Server is shutting down![/]", extra={"markup": True})
+
+Similarly, the highlighter may be overridden per log message::
+
+    log.error("123 will not be highlighted", extra={"highlighter": None})
 
 
 Handle exceptions

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -10,6 +10,7 @@ from .console import Console, ConsoleRenderable
 from .highlighter import Highlighter, ReprHighlighter
 from .text import Text
 from .traceback import Traceback
+from rich import highlighter
 
 
 class RichHandler(Handler):
@@ -168,8 +169,13 @@ class RichHandler(Handler):
             getattr(record, "markup") if hasattr(record, "markup") else self.markup
         )
         message_text = Text.from_markup(message) if use_markup else Text(message)
-        if self.highlighter:
-            message_text = self.highlighter(message_text)
+        highlighter = (
+            getattr(record, "highlighter")
+            if hasattr(record, "highlighter")
+            else self.highlighter
+        )
+        if highlighter:
+            message_text = highlighter(message_text)
         if self.KEYWORDS:
             message_text.highlight_words(self.KEYWORDS, "logging.keyword")
         return message_text

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -165,17 +165,13 @@ class RichHandler(Handler):
         Returns:
             ConsoleRenderable: Renderable to display log message.
         """
-        use_markup = (
-            getattr(record, "markup") if hasattr(record, "markup") else self.markup
-        )
+        use_markup = getattr(record, "markup", self.markup)
         message_text = Text.from_markup(message) if use_markup else Text(message)
-        highlighter = (
-            getattr(record, "highlighter")
-            if hasattr(record, "highlighter")
-            else self.highlighter
-        )
+
+        highlighter = getattr(record, "highlighter", self.highlighter)
         if highlighter:
             message_text = highlighter(message_text)
+
         if self.KEYWORDS:
             message_text.highlight_words(self.KEYWORDS, "logging.keyword")
         return message_text

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -10,7 +10,6 @@ from .console import Console, ConsoleRenderable
 from .highlighter import Highlighter, ReprHighlighter
 from .text import Text
 from .traceback import Traceback
-from rich import highlighter
 
 
 class RichHandler(Handler):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -122,6 +122,46 @@ def test_stderr_and_stdout_are_none(monkeypatch):
     assert "message" in actual_record.msg
 
 
+def test_markup_and_highlight():
+    console = Console(
+        file=io.StringIO(),
+        force_terminal=True,
+        width=140,
+        color_system="truecolor",
+        _environ={},
+    )
+    handler = RichHandler(console=console)
+
+    # Check defaults are as expected
+    assert handler.highlighter
+    assert not handler.markup
+
+    formatter = logging.Formatter("FORMATTER %(message)s %(asctime)s")
+    handler.setFormatter(formatter)
+    log.addHandler(handler)
+
+    log_message = "foo 3.141 127.0.0.1 [red]alert[/red]"
+
+    log.error(log_message)
+    render_fancy = handler.console.file.getvalue()
+    assert "FORMATTER" in render_fancy
+    assert log_message not in render_fancy
+    assert "red" in render_fancy
+
+    handler.console.file = io.StringIO()
+    log.error(log_message, extra={"markup": True})
+    render_markup = handler.console.file.getvalue()
+    assert "FORMATTER" in render_markup
+    assert log_message not in render_markup
+    assert "red" not in render_markup
+
+    handler.console.file = io.StringIO()
+    log.error(log_message, extra={"highlighter": None})
+    render_plain = handler.console.file.getvalue()
+    assert "FORMATTER" in render_plain
+    assert log_message in render_plain
+
+
 if __name__ == "__main__":
     render = make_log()
     print(render)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [X] New feature
- [X] Documentation / docstrings
- [X] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

This adds support for overriding the log highlighter per log message.

It also adds a test for the per log message markup and highlight overrides.
