### PR TITLE
Add support for indices in Prompt

### DIFF
--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -178,7 +178,7 @@ class PromptBase(Generic[PromptType]):
             prompt.append(choices, "prompt.choices")
         elif self.show_choices and self.choices and self.show_digits:
             prompt = Text()
-            _choices_list = []
+            _choices_list: List[str] = []
             for index, choice in enumerate(self.choices):
                 _choices_list.append(f"[{index+1}] {choice}")
             choices = "\n".join(_choices_list)
@@ -191,9 +191,10 @@ class PromptBase(Generic[PromptType]):
             and isinstance(default, (str, self.response_type))
         ):
             prompt.append(" ")
+            _default = ""
             if not self.show_digits:
                 _default = self.render_default(default)
-            else:
+            elif self.choices is not None:
                 _default = self.render_default(self.choices.index(default) + 1)
             prompt.append(_default)
 
@@ -261,8 +262,10 @@ class PromptBase(Generic[PromptType]):
             raise InvalidResponse(self.illegal_choice_message)
         if not self.show_digits:
             return return_value  # type: ignore
-        else:
+        elif self.choices is not None:
             return self.choices[int(value) - 1]  # type: ignore
+        else:
+            return ""  # type: ignore
 
     def on_validate_error(self, value: str, error: InvalidResponse) -> None:
         """Called to handle validation error.

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -160,7 +160,6 @@ class PromptBase(Generic[PromptType]):
         return Text(f"({default})", "prompt.default")
 
     def make_prompt(self, default: DefaultType) -> Text:
-        # print('ok')
         """Make prompt text.
 
         Args:
@@ -184,7 +183,7 @@ class PromptBase(Generic[PromptType]):
                 _choices_list.append(f"[{index+1}] {choice}")
             choices = "\n".join(_choices_list)
             prompt.append(choices, "prompt.choices")
-            prompt.append('\n')
+            prompt.append("\n")
             prompt.append(self.prompt.copy())
         if (
             default != ...


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Addresses #1776 

Adds a new parameter `show_digits` which when set to `True` (`False` by default), allows the user to select by the item's index rather than its text. 

For example

```
from rich.prompt import Prompt

choices = ["Some really long and annoying thing to type", "Another really long..."]
print(
    Prompt.ask(
        "pick one", choices=choices, show_digits=True, default="Another really long..."
    )
)
```

has the following output 

![image](https://user-images.githubusercontent.com/10794178/147373370-d9f3c77d-6996-4ab6-bbde-ceb5a72e919f.png)

Currently, if `show_digits` is set to `True`, only selections based on the index are allowed. 